### PR TITLE
fix: mantém dashboard de PRs consistente por app

### DIFF
--- a/src/apiService.js
+++ b/src/apiService.js
@@ -66,8 +66,10 @@ const addTenantMember = (tenantId, data) => apiRequest(`/tenants/${tenantId}/mem
 const fetchNotifications = (onlyUnread) => apiRequest(`/Notifications${onlyUnread ? "?onlyUnread=true" : ""}`);
 const markNotificationRead = (id) => apiRequest(`/Notifications/${id}/read`, { method: "PUT" });
 
-async function fetchPRs() {
-  const url = `${ApiConstants.BASE_URL}/PullRequests`;
+async function fetchPRs(appId = null) {
+  const url = appId
+    ? `${ApiConstants.BASE_URL}/Apps/${appId}/PullRequests`
+    : `${ApiConstants.BASE_URL}/PullRequests`;
 
   try {
     const response = await fetch(url, {
@@ -281,8 +283,10 @@ async function saveVersionBatch(batchData) {
   }
 }
 
-async function fetchBatches() {
-  const url = `${ApiConstants.BASE_URL}/VersionBatches`;
+async function fetchBatches(appId = null) {
+  const url = appId
+    ? `${ApiConstants.BASE_URL}/Apps/${appId}/VersionBatches`
+    : `${ApiConstants.BASE_URL}/VersionBatches`;
   try {
     const response = await fetch(url, { headers: getBackendHeaders() });
     return response.ok ? await response.json() : [];

--- a/src/appsHome.js
+++ b/src/appsHome.js
@@ -74,8 +74,10 @@ async function renderApps() {
 
     appsGrid.querySelectorAll('.app-enter-btn').forEach(btn =>
         btn.addEventListener('click', () => {
-            // dashboard filtrado por app (Project == nome até o Épico 5)
-            window.location.href = `index.html?app=${encodeURIComponent(btn.dataset.name)}`;
+            const app = appsState.find(item => item.name === btn.dataset.name);
+            const params = new URLSearchParams({ app: btn.dataset.name });
+            if (app?.id) params.set('appId', app.id);
+            window.location.href = `index.html?${params.toString()}`;
         }));
     appsGrid.querySelectorAll('.app-members-btn').forEach(btn =>
         btn.addEventListener('click', () => openMembers(btn.dataset.id)));

--- a/src/domService.js
+++ b/src/domService.js
@@ -1,5 +1,5 @@
 import { getItem } from './localStorageService.js';
-import { extractJiraId } from './utils.js';
+import { extractJiraId, isOpenPullRequest } from './utils.js';
 import * as AuthService from './authService.js';
 import { DEMO_MODE, DEMO_USERS, getDemoProject, getDemoName } from './constants/apiConstants.js';
 
@@ -225,10 +225,11 @@ function enableEscapeToCloseModals() {
 }
 
 function renderTable(prs, batches, sprints, onEdit, animate = true) {
-    const openPrs = prs.filter(p => !p.approved);
+    const openPrs = prs.filter(isOpenPullRequest);
     
     const approvedTotal = prs.filter(p => p.approved);
-    const approvedPending = approvedTotal.filter(p => !p.deployedToStg);
+    const approvedPending = approvedTotal.filter(p =>
+        !p.deployedToStg && !isOpenPullRequest(p));
     
     const activeSprints = sprints.filter(s => s.isActive);
     const inactiveSprints = sprints.filter(s => !s.isActive);

--- a/src/script.js
+++ b/src/script.js
@@ -5,7 +5,7 @@ import * as AuthService from './authService.js';
 import { GitLabService } from './automationService.js';
 import { EffectService } from './effectService.js';
 import { CURRENT_VERSION } from './modules/changelog/changelog.data.js';
-import { extractJiraId } from './utils.js';
+import { extractJiraId, isOpenPullRequest } from './utils.js';
 import { connectSignalR } from './notificationService.js';
 import { isLocalDev, DEMO_MODE, DEMO_USERS, getDemoProject } from './constants/apiConstants.js';
 import { initializeTheme } from './themeService.js';
@@ -13,9 +13,11 @@ import { initializeTheme } from './themeService.js';
 let currentData = { prs: [] };
 let availableUsers = [];
 
-// Filtro por app (Épico 3): apps.html manda para index.html?app=<nome>;
-// a ligação é pelo nome do projeto até o Épico 5 trocar por FK.
-const appFilter = new URLSearchParams(window.location.search).get('app');
+// appId é a referência estável. `app` continua na URL para exibição e compatibilidade
+// com links antigos criados antes das rotas escopadas por aplicação.
+const appParams = new URLSearchParams(window.location.search);
+let appFilter = appParams.get('app');
+const appIdFilter = appParams.get('appId');
 // id do app filtrado (resolvido quando a lista de apps carrega) — usado pela config por app
 let currentAppId = null;
 
@@ -48,8 +50,10 @@ async function loadProjectOptions() {
             }
         }
 
-        if (appFilter) {
-            const app = apps.find(a => a.name === appFilter);
+        if (appIdFilter || appFilter) {
+            const app = apps.find(a => a.id === appIdFilter)
+                ?? apps.find(a => a.name === appFilter);
+            if (app) appFilter = app.name;
             AuthService.setCurrentAppRole(app?.myRole ?? null);
             currentAppId = app?.id ?? null; // Épico 7.3: config de automação por app
 
@@ -738,20 +742,22 @@ async function confirmRequestVersionSelection() {
 }
 
 async function loadPrTablesData(animate = false) {
-    const prResult = await API.fetchPRs();
+    const prResult = await API.fetchPRs(currentAppId);
     if (!prResult || !Array.isArray(prResult.prs)) {
         throw new Error('Falha ao carregar PRs');
     }
-    currentData.prs = appFilter
+    // Links novos consultam a rota escopada por AppId. O filtro textual fica somente
+    // como fallback para links antigos (`?app=nome`) ainda compartilhados/salvos.
+    currentData.prs = appFilter && !currentAppId
         ? prResult.prs.filter(p => p.project === appFilter)
         : prResult.prs;
     refreshOpenPrs(animate);
 
-    const batches = await API.fetchBatches();
+    const batches = await API.fetchBatches(currentAppId);
     if (!Array.isArray(batches)) {
         throw new Error('Falha ao carregar lotes');
     }
-    currentData.batches = appFilter
+    currentData.batches = appFilter && !currentAppId
         ? batches.filter(b => b.project === appFilter)
         : batches;
     refreshApprovedPrs(animate);
@@ -799,7 +805,7 @@ async function loadData(skipLoading = false) {
 }
 
 function refreshOpenPrs(animate = false) {
-    const openPrs = currentData.prs.filter(p => !p.approved);
+    const openPrs = currentData.prs.filter(isOpenPullRequest);
     const totalOpenBadge = document.getElementById('totalOpenPrs');
     if (totalOpenBadge) {
         totalOpenBadge.textContent = openPrs.length;
@@ -813,7 +819,8 @@ function refreshOpenPrs(animate = false) {
 function refreshApprovedPrs(animate = false) {
     if (!Array.isArray(currentData.batches)) return;
 
-    const approvedPending = currentData.prs.filter(p => p.approved && !p.deployedToStg);
+    const approvedPending = currentData.prs.filter(p =>
+        p.approved && !p.deployedToStg && !isOpenPullRequest(p));
     DOM.renderApprovedTables(approvedPending, currentData.batches, 'dashboardApproved', openEditModal, animate);
     if (window.lucide) window.lucide.createIcons();
     if (AuthService && AuthService.applyRoleBasedVisibility) AuthService.applyRoleBasedVisibility();

--- a/src/utils.js
+++ b/src/utils.js
@@ -9,3 +9,7 @@ export function extractJiraId(url) {
     const match = url.match(regex);
     return match ? match[1].toUpperCase() : null;
 }
+
+export function isOpenPullRequest(pr) {
+    return pr?.status === 'Open' || pr?.status === 'NeedsCorrection';
+}


### PR DESCRIPTION
## Resumo
- navega da home para o dashboard com o `AppId` estável
- consulta PRs e lotes pelas rotas escopadas por aplicação
- mantém fallback para links antigos baseados no nome do app
- alinha a definição de PR aberto com os status `Open` e `NeedsCorrection` do backend

Parte frontend de SamuelAraag/pr-manager#12.

## Validação
- `node --check` nos módulos alterados
- verificação da classificação dos status abertos
- `git diff --check`