### PR TITLE
fix: corrige filtro do dashboard por app para usar AppId (não texto de Project)

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -13,10 +13,12 @@ import { initializeTheme } from './themeService.js';
 let currentData = { prs: [] };
 let availableUsers = [];
 
-// Filtro por app (Épico 3): apps.html manda para index.html?app=<nome>;
-// a ligação é pelo nome do projeto até o Épico 5 trocar por FK.
+// Filtro por app (Épico 3): apps.html manda para index.html?app=<nome>. O nome na URL só
+// resolve o app (abaixo, currentAppId); a listagem de PRs/lotes filtra por AppId (FK), não
+// pelo texto de Project — PRs com Project divergente do nome atual do app (rename, dado
+// legado) não podem sumir da lista enquanto continuam contados no card da tela Apps.
 const appFilter = new URLSearchParams(window.location.search).get('app');
-// id do app filtrado (resolvido quando a lista de apps carrega) — usado pela config por app
+// id do app filtrado (resolvido quando a lista de apps carrega) — chave real do filtro de PRs/lotes
 let currentAppId = null;
 
 initializeTheme('themeToggleBtn');
@@ -743,7 +745,7 @@ async function loadPrTablesData(animate = false) {
         throw new Error('Falha ao carregar PRs');
     }
     currentData.prs = appFilter
-        ? prResult.prs.filter(p => p.project === appFilter)
+        ? prResult.prs.filter(p => p.appId === currentAppId)
         : prResult.prs;
     refreshOpenPrs(animate);
 
@@ -752,7 +754,7 @@ async function loadPrTablesData(animate = false) {
         throw new Error('Falha ao carregar lotes');
     }
     currentData.batches = appFilter
-        ? batches.filter(b => b.project === appFilter)
+        ? batches.filter(b => b.appId === currentAppId)
         : batches;
     refreshApprovedPrs(animate);
 }


### PR DESCRIPTION
## Resumo
- O dashboard filtrado por app (`index.html?app=<nome>`) comparava o campo de texto livre `Project` de cada PR/lote de versão com o nome do app vindo da URL, em vez de usar o `AppId` (FK estável, já exposto pela API).
- PRs cujo `Project` divergisse do nome atual do app (rename, dado legado, digitação diferente) somiam da lista filtrada — mesmo continuando contados normalmente no card de "abertos" da tela Apps, que já usa `AppId`. Isso causava contadores dessincronizados com a listagem real.
- Fix: `loadPrTablesData()` em `src/script.js` agora filtra PRs e lotes por `appId === currentAppId` (já resolvido antes, a partir da lista de apps carregada) em vez de `project === appFilter`.

## Plano de teste
- [x] Abrir um app com PRs cujo `Project` no banco não bata exatamente com o nome atual do app e confirmar que eles aparecem na lista `index.html?app=<nome>`.
- [x] Confirmar que a contagem exibida no card da tela Apps bate com a quantidade de PRs "em aberto" mostrados no dashboard filtrado por esse app.
- [x] Confirmar que o dashboard sem filtro (`index.html` sem `?app=`) continua mostrando todos os PRs normalmente.

Issue: https://github.com/SamuelAraag/pr-manager/issues/12