### PR TITLE
fix: substitui prompt() nativo por modal na criação de Sprint

### DIFF
--- a/index.html
+++ b/index.html
@@ -293,13 +293,36 @@
                     <span class="field-error" id="newSprintNameError">Informe o nome da sprint.</span>
                 </div>
                 <div class="form-group full-width">
-                    <label for="newSprintStartDateInput">Data de início (opcional)</label>
-                    <input type="date" id="newSprintStartDateInput">
-                </div>
-                <div class="form-group full-width">
-                    <label for="newSprintEndDateInput">Data de término (opcional)</label>
-                    <input type="date" id="newSprintEndDateInput">
-                    <span class="field-error" id="newSprintEndDateError">Data de término não pode ser antes da data de início.</span>
+                    <label id="sprintDateRangeLabel">Período (opcional)</label>
+                    <div class="date-range-field" id="sprintDateRangeField">
+                        <input type="text" id="newSprintStartDateInput" placeholder="Data início" inputmode="numeric" autocomplete="off">
+                        <i class="date-range-arrow" data-lucide="arrow-right" aria-hidden="true"></i>
+                        <input type="text" id="newSprintEndDateInput" placeholder="Data fim" inputmode="numeric" autocomplete="off">
+                        <button type="button" class="date-range-calendar-btn" id="sprintDateRangeCalendarBtn" aria-label="Abrir calendário" title="Abrir calendário">
+                            <i data-lucide="calendar"></i>
+                        </button>
+
+                        <div class="date-range-popover" id="sprintDateRangePopover">
+                            <div class="date-range-popover-header">
+                                <button type="button" class="date-range-nav-btn" id="sprintDrPrevMonth" aria-label="Mês anterior"><i data-lucide="chevron-left"></i></button>
+                                <span class="date-range-month-label" id="sprintDrMonthLabel"></span>
+                                <button type="button" class="date-range-nav-btn" id="sprintDrNextMonth" aria-label="Próximo mês"><i data-lucide="chevron-right"></i></button>
+                            </div>
+                            <div class="date-range-weekdays">
+                                <span>D</span><span>S</span><span>T</span><span>Q</span><span>Q</span><span>S</span><span>S</span>
+                            </div>
+                            <div class="date-range-days" id="sprintDrDaysGrid"></div>
+                            <div class="date-range-summary">
+                                <span>Início: <strong id="sprintDrSummaryStart">—</strong></span>
+                                <span>Fim: <strong id="sprintDrSummaryEnd">—</strong></span>
+                            </div>
+                            <div class="date-range-popover-actions">
+                                <button type="button" class="btn btn-outline" id="sprintDrCancelBtn">Cancelar</button>
+                                <button type="button" class="btn btn-primary" id="sprintDrApplyBtn">Aplicar</button>
+                            </div>
+                        </div>
+                    </div>
+                    <span class="field-error" id="newSprintDateRangeError">Data fim não pode ser antes da data início.</span>
                 </div>
                 <div style="display: flex; justify-content: flex-end; gap: 0.75rem;">
                     <button id="cancelNewSprintModalBtn" class="btn btn-outline close-modal" type="button">Cancelar</button>

--- a/index.html
+++ b/index.html
@@ -280,6 +280,33 @@
         </div>
     </div>
 
+    <div id="newSprintModal" class="modal-overlay">
+        <div class="modal-content" style="max-width: 420px;">
+            <div class="modal-header">
+                <h2>Nova Sprint</h2>
+                <button class="close-btn">&times;</button>
+            </div>
+            <div style="display: flex; flex-direction: column; gap: 1rem;">
+                <div class="form-group full-width">
+                    <label for="newSprintNameInput">Nome da Sprint</label>
+                    <input type="text" id="newSprintNameInput" placeholder="ex: Sprint 28">
+                </div>
+                <div class="form-group full-width">
+                    <label for="newSprintStartDateInput">Data de início (opcional)</label>
+                    <input type="date" id="newSprintStartDateInput">
+                </div>
+                <div class="form-group full-width">
+                    <label for="newSprintEndDateInput">Data de término (opcional)</label>
+                    <input type="date" id="newSprintEndDateInput">
+                </div>
+                <div style="display: flex; justify-content: flex-end; gap: 0.75rem;">
+                    <button id="cancelNewSprintModalBtn" class="btn btn-outline close-modal" type="button">Cancelar</button>
+                    <button id="confirmNewSprintBtn" class="btn btn-primary" type="button">Criar Sprint</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
 
     </div>
     <!-- Setup Modal (Token) -->

--- a/index.html
+++ b/index.html
@@ -295,9 +295,9 @@
                 <div class="form-group full-width">
                     <label id="sprintDateRangeLabel">Período (opcional)</label>
                     <div class="date-range-field" id="sprintDateRangeField">
-                        <input type="text" id="newSprintStartDateInput" placeholder="Data início" inputmode="numeric" autocomplete="off">
+                        <input type="text" id="newSprintStartDateInput" placeholder="Data início" inputmode="numeric" autocomplete="off" maxlength="10">
                         <i class="date-range-arrow" data-lucide="arrow-right" aria-hidden="true"></i>
-                        <input type="text" id="newSprintEndDateInput" placeholder="Data fim" inputmode="numeric" autocomplete="off">
+                        <input type="text" id="newSprintEndDateInput" placeholder="Data fim" inputmode="numeric" autocomplete="off" maxlength="10">
                         <button type="button" class="date-range-calendar-btn" id="sprintDateRangeCalendarBtn" aria-label="Abrir calendário" title="Abrir calendário">
                             <i data-lucide="calendar"></i>
                         </button>

--- a/index.html
+++ b/index.html
@@ -290,6 +290,7 @@
                 <div class="form-group full-width">
                     <label for="newSprintNameInput">Nome da Sprint</label>
                     <input type="text" id="newSprintNameInput" placeholder="ex: Sprint 28">
+                    <span class="field-error" id="newSprintNameError">Informe o nome da sprint.</span>
                 </div>
                 <div class="form-group full-width">
                     <label for="newSprintStartDateInput">Data de início (opcional)</label>
@@ -298,6 +299,7 @@
                 <div class="form-group full-width">
                     <label for="newSprintEndDateInput">Data de término (opcional)</label>
                     <input type="date" id="newSprintEndDateInput">
+                    <span class="field-error" id="newSprintEndDateError">Data de término não pode ser antes da data de início.</span>
                 </div>
                 <div style="display: flex; justify-content: flex-end; gap: 0.75rem;">
                     <button id="cancelNewSprintModalBtn" class="btn btn-outline close-modal" type="button">Cancelar</button>

--- a/index.html
+++ b/index.html
@@ -322,7 +322,7 @@
                             </div>
                         </div>
                     </div>
-                    <span class="field-error" id="newSprintDateRangeError">Data fim não pode ser antes da data início.</span>
+                    <span class="field-error" id="newSprintDateRangeError">Data fim precisa ser depois da data início.</span>
                 </div>
                 <div style="display: flex; justify-content: flex-end; gap: 0.75rem;">
                     <button id="cancelNewSprintModalBtn" class="btn btn-outline close-modal" type="button">Cancelar</button>

--- a/src/dateRangePicker.js
+++ b/src/dateRangePicker.js
@@ -157,11 +157,12 @@ export function initDateRangePicker({
     }
 
     function handleDayClick(date) {
-        if (!pendingStart || pendingEnd) {
+        // Fim precisa ser estritamente depois do início — clicar num dia igual ou anterior
+        // ao início já selecionado reinicia o range a partir desse dia, em vez de criar um
+        // período de 1 dia só (início === fim).
+        if (!pendingStart || pendingEnd || date <= pendingStart) {
             pendingStart = date;
             pendingEnd = null;
-        } else if (date < pendingStart) {
-            pendingStart = date;
         } else {
             pendingEnd = date;
         }
@@ -234,13 +235,14 @@ export function initDateRangePicker({
             return;
         }
 
+        // Fim precisa ser estritamente maior que início — data igual também é inválida.
         const other = fromISO((isStart ? endInput : startInput).dataset.iso || '');
-        if (isStart && other && parsed > other) {
-            showError('Data início não pode ser depois da data fim.');
+        if (isStart && other && parsed >= other) {
+            showError('Data início precisa ser antes da data fim.');
             return;
         }
-        if (!isStart && other && parsed < other) {
-            showError('Data fim não pode ser antes da data início.');
+        if (!isStart && other && parsed <= other) {
+            showError('Data fim precisa ser depois da data início.');
             return;
         }
 

--- a/src/dateRangePicker.js
+++ b/src/dateRangePicker.js
@@ -219,41 +219,50 @@ export function initDateRangePicker({
 
     cancelBtn.addEventListener('click', closePopover);
 
-    function handleManualInput(input, isStart) {
-        const raw = input.value.trim();
+    // Valida os dois campos de texto juntos (não um de cada vez) e só então grava em
+    // dataset.iso — evita que validar o segundo campo limpe o erro que acabou de aparecer
+    // no primeiro. Usado tanto no blur (feedback ao digitar) quanto no submit do modal
+    // (validate(), abaixo), pra garantir que uma data inválida nunca escape pro getRange().
+    function commitDates() {
         clearError();
 
-        if (!raw) {
-            input.dataset.iso = '';
-            notifyChange();
-            return;
+        const startRaw = startInput.value.trim();
+        const endRaw = endInput.value.trim();
+        let startDate = null;
+        let endDate = null;
+
+        if (startRaw) {
+            startDate = parseDisplay(startRaw);
+            if (!startDate) {
+                showError('Data início inválida. Use o formato DD/MM/AAAA.');
+                return false;
+            }
         }
 
-        const parsed = parseDisplay(raw);
-        if (!parsed) {
-            showError('Data inválida. Use o formato DD/MM/AAAA.');
-            return;
+        if (endRaw) {
+            endDate = parseDisplay(endRaw);
+            if (!endDate) {
+                showError('Data fim inválida. Use o formato DD/MM/AAAA.');
+                return false;
+            }
         }
 
         // Fim precisa ser estritamente maior que início — data igual também é inválida.
-        const other = fromISO((isStart ? endInput : startInput).dataset.iso || '');
-        if (isStart && other && parsed >= other) {
-            showError('Data início precisa ser antes da data fim.');
-            return;
-        }
-        if (!isStart && other && parsed <= other) {
+        if (startDate && endDate && endDate <= startDate) {
             showError('Data fim precisa ser depois da data início.');
-            return;
+            return false;
         }
 
-        input.dataset.iso = toISO(parsed);
+        startInput.dataset.iso = startDate ? toISO(startDate) : '';
+        endInput.dataset.iso = endDate ? toISO(endDate) : '';
         notifyChange();
+        return true;
     }
 
     applyDateMask(startInput);
     applyDateMask(endInput);
-    startInput.addEventListener('blur', () => handleManualInput(startInput, true));
-    endInput.addEventListener('blur', () => handleManualInput(endInput, false));
+    startInput.addEventListener('blur', commitDates);
+    endInput.addEventListener('blur', commitDates);
     startInput.addEventListener('input', clearError);
     endInput.addEventListener('input', clearError);
 
@@ -268,6 +277,12 @@ export function initDateRangePicker({
             clearError();
             closePopover();
             setApplied(null, null);
+        },
+        // Reaplica a validação nos dois campos (cobre o caso do usuário digitar e clicar
+        // direto em "Criar Sprint" sem tirar o foco do input, sem passar pelo blur) e
+        // devolve se está tudo certo — quem chama deve bloquear o submit se vier false.
+        validate() {
+            return commitDates();
         }
     };
 }

--- a/src/dateRangePicker.js
+++ b/src/dateRangePicker.js
@@ -82,9 +82,11 @@ export function initDateRangePicker({
         errorEl?.classList.remove('visible');
     }
 
-    function showError(message) {
-        startInput.classList.add('is-invalid');
-        endInput.classList.add('is-invalid');
+    // fields: só os campos que causaram o erro ficam vermelhos. Marcar os dois sempre
+    // deixava borda de erro num campo vazio e opcional (ex.: erro de formato no início
+    // pintava o fim também), resíduo visual que sobrava depois de corrigir o outro campo.
+    function showError(message, fields) {
+        (fields ?? [startInput, endInput]).forEach(field => field.classList.add('is-invalid'));
         if (errorEl) {
             errorEl.textContent = message;
             errorEl.classList.add('visible');
@@ -174,7 +176,11 @@ export function initDateRangePicker({
     }
 
     function handleKeydown(e) {
-        if (e.key === 'Escape') closePopover();
+        if (e.key !== 'Escape') return;
+        closePopover();
+        // Impede que o mesmo Esc que fechou o calendário feche também o modal que o contém
+        // — o primeiro Esc fecha o popover, o segundo fecha o modal.
+        e.stopPropagation();
     }
 
     function openPopover() {
@@ -234,7 +240,7 @@ export function initDateRangePicker({
         if (startRaw) {
             startDate = parseDisplay(startRaw);
             if (!startDate) {
-                showError('Data início inválida. Use o formato DD/MM/AAAA.');
+                showError('Data início inválida. Use o formato DD/MM/AAAA.', [startInput]);
                 return false;
             }
         }
@@ -242,14 +248,14 @@ export function initDateRangePicker({
         if (endRaw) {
             endDate = parseDisplay(endRaw);
             if (!endDate) {
-                showError('Data fim inválida. Use o formato DD/MM/AAAA.');
+                showError('Data fim inválida. Use o formato DD/MM/AAAA.', [endInput]);
                 return false;
             }
         }
 
         // Fim precisa ser estritamente maior que início — data igual também é inválida.
         if (startDate && endDate && endDate <= startDate) {
-            showError('Data fim precisa ser depois da data início.');
+            showError('Data fim precisa ser depois da data início.', [startInput, endInput]);
             return false;
         }
 

--- a/src/dateRangePicker.js
+++ b/src/dateRangePicker.js
@@ -38,6 +38,31 @@ function parseDisplay(str) {
 const stripTime = (date) => new Date(date.getFullYear(), date.getMonth(), date.getDate());
 const sameDay = (a, b) => !!a && !!b && a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth() && a.getDate() === b.getDate();
 
+// Máscara DD/MM/AAAA: insere as barras sozinho enquanto o usuário digita só números,
+// mantendo o cursor na posição certa (conta dígitos antes do cursor, não caracteres).
+function applyDateMask(input) {
+    input.addEventListener('input', () => {
+        const digitsBeforeCursor = input.value.slice(0, input.selectionStart).replace(/\D/g, '').length;
+
+        const digits = input.value.replace(/\D/g, '').slice(0, 8);
+        let formatted = digits;
+        if (digits.length > 4) {
+            formatted = `${digits.slice(0, 2)}/${digits.slice(2, 4)}/${digits.slice(4)}`;
+        } else if (digits.length > 2) {
+            formatted = `${digits.slice(0, 2)}/${digits.slice(2)}`;
+        }
+        input.value = formatted;
+
+        let digitsSeen = 0;
+        let cursorPos = formatted.length;
+        for (let i = 0; i < formatted.length; i++) {
+            if (digitsSeen === digitsBeforeCursor) { cursorPos = i; break; }
+            if (/\d/.test(formatted[i])) digitsSeen++;
+        }
+        input.setSelectionRange(cursorPos, cursorPos);
+    });
+}
+
 export function initDateRangePicker({
     fieldEl, startInput, endInput, calendarBtn, popoverEl,
     prevBtn, nextBtn, monthLabelEl, daysGridEl,
@@ -223,6 +248,8 @@ export function initDateRangePicker({
         notifyChange();
     }
 
+    applyDateMask(startInput);
+    applyDateMask(endInput);
     startInput.addEventListener('blur', () => handleManualInput(startInput, true));
     endInput.addEventListener('blur', () => handleManualInput(endInput, false));
     startInput.addEventListener('input', clearError);

--- a/src/dateRangePicker.js
+++ b/src/dateRangePicker.js
@@ -1,0 +1,244 @@
+// Componente de período (data início/fim) reutilizável — issue pr-manager-cloud#18.
+// Markup estático (index.html) + esta função liga os elementos, mesmo padrão de
+// domService.confirmDialog/alertDialog. Fonte de verdade é ISO (YYYY-MM-DD), guardada em
+// dataset.iso dos inputs; exibição é sempre DD/MM/AAAA.
+
+const MONTH_NAMES = [
+    'Janeiro', 'Fevereiro', 'Março', 'Abril', 'Maio', 'Junho',
+    'Julho', 'Agosto', 'Setembro', 'Outubro', 'Novembro', 'Dezembro'
+];
+
+const pad2 = (n) => String(n).padStart(2, '0');
+
+const toISO = (date) => `${date.getFullYear()}-${pad2(date.getMonth() + 1)}-${pad2(date.getDate())}`;
+
+function fromISO(iso) {
+    if (!iso) return null;
+    const [y, m, d] = iso.split('-').map(Number);
+    if (!y || !m || !d) return null;
+    const date = new Date(y, m - 1, d);
+    return Number.isNaN(date.getTime()) ? null : date;
+}
+
+const formatDisplay = (date) => date ? `${pad2(date.getDate())}/${pad2(date.getMonth() + 1)}/${date.getFullYear()}` : '';
+
+function parseDisplay(str) {
+    const match = /^(\d{2})\/(\d{2})\/(\d{4})$/.exec((str || '').trim());
+    if (!match) return null;
+    const [, d, m, y] = match;
+    const date = new Date(Number(y), Number(m) - 1, Number(d));
+    // new Date() "conserta" datas inválidas (ex.: 31/02 vira 03/03) em vez de rejeitar —
+    // comparar de volta com o que foi digitado é o jeito de pegar isso.
+    if (date.getFullYear() !== Number(y) || date.getMonth() !== Number(m) - 1 || date.getDate() !== Number(d)) {
+        return null;
+    }
+    return date;
+}
+
+const stripTime = (date) => new Date(date.getFullYear(), date.getMonth(), date.getDate());
+const sameDay = (a, b) => !!a && !!b && a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth() && a.getDate() === b.getDate();
+
+export function initDateRangePicker({
+    fieldEl, startInput, endInput, calendarBtn, popoverEl,
+    prevBtn, nextBtn, monthLabelEl, daysGridEl,
+    summaryStartEl, summaryEndEl, applyBtn, cancelBtn, errorEl, onChange
+}) {
+    let pendingStart = null;
+    let pendingEnd = null;
+    let viewYear = 0;
+    let viewMonth = 0;
+
+    const getAppliedStart = () => fromISO(startInput.dataset.iso || '');
+    const getAppliedEnd = () => fromISO(endInput.dataset.iso || '');
+
+    function clearError() {
+        startInput.classList.remove('is-invalid');
+        endInput.classList.remove('is-invalid');
+        errorEl?.classList.remove('visible');
+    }
+
+    function showError(message) {
+        startInput.classList.add('is-invalid');
+        endInput.classList.add('is-invalid');
+        if (errorEl) {
+            errorEl.textContent = message;
+            errorEl.classList.add('visible');
+        }
+    }
+
+    function notifyChange() {
+        onChange?.(startInput.dataset.iso || null, endInput.dataset.iso || null);
+    }
+
+    function setApplied(startDate, endDate) {
+        startInput.value = formatDisplay(startDate);
+        startInput.dataset.iso = startDate ? toISO(startDate) : '';
+        endInput.value = formatDisplay(endDate);
+        endInput.dataset.iso = endDate ? toISO(endDate) : '';
+        notifyChange();
+    }
+
+    function renderMonthLabel() {
+        monthLabelEl.textContent = `${MONTH_NAMES[viewMonth]} ${viewYear}`;
+    }
+
+    function renderDays() {
+        daysGridEl.innerHTML = '';
+        const firstOfMonth = new Date(viewYear, viewMonth, 1);
+        const gridStart = new Date(viewYear, viewMonth, 1 - firstOfMonth.getDay());
+        const today = stripTime(new Date());
+
+        for (let i = 0; i < 42; i++) {
+            const cellDate = new Date(gridStart.getFullYear(), gridStart.getMonth(), gridStart.getDate() + i);
+            const inCurrentMonth = cellDate.getMonth() === viewMonth;
+
+            const cell = document.createElement('div');
+            cell.className = 'date-range-day';
+            cell.textContent = String(cellDate.getDate());
+
+            if (!inCurrentMonth) cell.classList.add('is-other-month');
+            if (sameDay(cellDate, today)) cell.classList.add('is-today');
+            if (pendingStart && pendingEnd && cellDate > pendingStart && cellDate < pendingEnd) cell.classList.add('in-range');
+            if (pendingStart && sameDay(cellDate, pendingStart)) cell.classList.add('is-start');
+            if (pendingEnd && sameDay(cellDate, pendingEnd)) cell.classList.add('is-end');
+
+            if (inCurrentMonth) {
+                cell.tabIndex = 0;
+                cell.setAttribute('role', 'button');
+                cell.setAttribute('aria-label', formatDisplay(cellDate));
+                cell.addEventListener('click', () => handleDayClick(cellDate));
+                cell.addEventListener('keydown', (e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        handleDayClick(cellDate);
+                    }
+                });
+            }
+
+            daysGridEl.appendChild(cell);
+        }
+    }
+
+    function renderSummary() {
+        summaryStartEl.textContent = pendingStart ? formatDisplay(pendingStart) : '—';
+        summaryEndEl.textContent = pendingEnd ? formatDisplay(pendingEnd) : '—';
+    }
+
+    function renderCalendar() {
+        renderMonthLabel();
+        renderDays();
+        renderSummary();
+        if (window.lucide) window.lucide.createIcons();
+    }
+
+    function handleDayClick(date) {
+        if (!pendingStart || pendingEnd) {
+            pendingStart = date;
+            pendingEnd = null;
+        } else if (date < pendingStart) {
+            pendingStart = date;
+        } else {
+            pendingEnd = date;
+        }
+        renderCalendar();
+    }
+
+    function handleOutsideClick(e) {
+        if (!fieldEl.contains(e.target)) closePopover();
+    }
+
+    function handleKeydown(e) {
+        if (e.key === 'Escape') closePopover();
+    }
+
+    function openPopover() {
+        pendingStart = getAppliedStart();
+        pendingEnd = getAppliedEnd();
+        const base = pendingStart || new Date();
+        viewYear = base.getFullYear();
+        viewMonth = base.getMonth();
+        renderCalendar();
+        popoverEl.classList.add('open');
+        document.addEventListener('mousedown', handleOutsideClick, true);
+        document.addEventListener('keydown', handleKeydown, true);
+    }
+
+    function closePopover() {
+        popoverEl.classList.remove('open');
+        document.removeEventListener('mousedown', handleOutsideClick, true);
+        document.removeEventListener('keydown', handleKeydown, true);
+    }
+
+    calendarBtn.addEventListener('click', () => {
+        popoverEl.classList.contains('open') ? closePopover() : openPopover();
+    });
+
+    prevBtn.addEventListener('click', () => {
+        viewMonth -= 1;
+        if (viewMonth < 0) { viewMonth = 11; viewYear -= 1; }
+        renderCalendar();
+    });
+
+    nextBtn.addEventListener('click', () => {
+        viewMonth += 1;
+        if (viewMonth > 11) { viewMonth = 0; viewYear += 1; }
+        renderCalendar();
+    });
+
+    applyBtn.addEventListener('click', () => {
+        clearError();
+        setApplied(pendingStart, pendingEnd);
+        closePopover();
+    });
+
+    cancelBtn.addEventListener('click', closePopover);
+
+    function handleManualInput(input, isStart) {
+        const raw = input.value.trim();
+        clearError();
+
+        if (!raw) {
+            input.dataset.iso = '';
+            notifyChange();
+            return;
+        }
+
+        const parsed = parseDisplay(raw);
+        if (!parsed) {
+            showError('Data inválida. Use o formato DD/MM/AAAA.');
+            return;
+        }
+
+        const other = fromISO((isStart ? endInput : startInput).dataset.iso || '');
+        if (isStart && other && parsed > other) {
+            showError('Data início não pode ser depois da data fim.');
+            return;
+        }
+        if (!isStart && other && parsed < other) {
+            showError('Data fim não pode ser antes da data início.');
+            return;
+        }
+
+        input.dataset.iso = toISO(parsed);
+        notifyChange();
+    }
+
+    startInput.addEventListener('blur', () => handleManualInput(startInput, true));
+    endInput.addEventListener('blur', () => handleManualInput(endInput, false));
+    startInput.addEventListener('input', clearError);
+    endInput.addEventListener('input', clearError);
+
+    return {
+        getRange() {
+            return { start: startInput.dataset.iso || null, end: endInput.dataset.iso || null };
+        },
+        setRange(startISO, endISO) {
+            setApplied(fromISO(startISO), fromISO(endISO));
+        },
+        reset() {
+            clearError();
+            closePopover();
+            setApplied(null, null);
+        }
+    };
+}

--- a/src/domService.js
+++ b/src/domService.js
@@ -5,6 +5,15 @@ import { DEMO_MODE, DEMO_USERS, getDemoProject, getDemoName } from './constants/
 
 const TOAST_STORAGE_KEY = 'pr_manager_toasts';
 
+// Escapa texto que vai ser interpolado em innerHTML. Usar sempre que o conteúdo puder vir
+// do usuário ou da API — o navegador faz o escape sozinho ao ler textContent de um nó
+// solto, sem precisar de regex/lista de caracteres.
+function escapeHtml(value) {
+    const div = document.createElement('div');
+    div.textContent = value ?? '';
+    return div.innerHTML;
+}
+
 const getProfileImage = (userName) => {
     const profileImages = {
         'Itallo Cerqueira': 'src/assets/profiles/itallo-cerqueira.png',
@@ -129,11 +138,14 @@ function showToast(message, type = 'success', title = '', isRestored = false) {
     if (type === 'warning') iconName = 'alert-triangle';
     if (type === 'info') iconName = 'info';
 
+    // escapeHtml em title/message: o toast é montado por innerHTML e vários callers
+    // interpolam texto digitado pelo usuário (ex.: nome da sprint em script.js) — sem
+    // escapar, um nome como "<img src=x onerror=...>" executa ao exibir o toast.
     toast.innerHTML = `
         <div class="toast-icon"><i data-lucide="${iconName}" width="20"></i></div>
         <div class="toast-content">
-            <span class="toast-title">${title}</span>
-            <div class="toast-message">${message}</div>
+            <span class="toast-title">${escapeHtml(title)}</span>
+            <div class="toast-message">${escapeHtml(message)}</div>
         </div>
         <button class="toast-close">&times;</button>
     `;

--- a/src/script.js
+++ b/src/script.js
@@ -9,6 +9,7 @@ import { extractJiraId } from './utils.js';
 import { connectSignalR } from './notificationService.js';
 import { isLocalDev, DEMO_MODE, DEMO_USERS, getDemoProject } from './constants/apiConstants.js';
 import { initializeTheme } from './themeService.js';
+import { initDateRangePicker } from './dateRangePicker.js';
 
 let currentData = { prs: [] };
 let availableUsers = [];
@@ -165,8 +166,24 @@ const newSprintNameInput = document.getElementById('newSprintNameInput');
 const newSprintNameError = document.getElementById('newSprintNameError');
 const newSprintStartDateInput = document.getElementById('newSprintStartDateInput');
 const newSprintEndDateInput = document.getElementById('newSprintEndDateInput');
-const newSprintEndDateError = document.getElementById('newSprintEndDateError');
 const confirmNewSprintBtn = document.getElementById('confirmNewSprintBtn');
+
+const sprintDateRangePicker = initDateRangePicker({
+    fieldEl: document.getElementById('sprintDateRangeField'),
+    startInput: newSprintStartDateInput,
+    endInput: newSprintEndDateInput,
+    calendarBtn: document.getElementById('sprintDateRangeCalendarBtn'),
+    popoverEl: document.getElementById('sprintDateRangePopover'),
+    prevBtn: document.getElementById('sprintDrPrevMonth'),
+    nextBtn: document.getElementById('sprintDrNextMonth'),
+    monthLabelEl: document.getElementById('sprintDrMonthLabel'),
+    daysGridEl: document.getElementById('sprintDrDaysGrid'),
+    summaryStartEl: document.getElementById('sprintDrSummaryStart'),
+    summaryEndEl: document.getElementById('sprintDrSummaryEnd'),
+    applyBtn: document.getElementById('sprintDrApplyBtn'),
+    cancelBtn: document.getElementById('sprintDrCancelBtn'),
+    errorEl: document.getElementById('newSprintDateRangeError')
+});
 const prForm = document.getElementById('prForm');
 const profileScreen = document.getElementById('profileScreen');
 const currentUserDisplay = document.getElementById('currentUserDisplay');
@@ -1114,15 +1131,11 @@ document.getElementById('logoutBtn').addEventListener('click', handleLogout);
 function clearNewSprintValidation() {
     newSprintNameInput?.classList.remove('is-invalid');
     newSprintNameError?.classList.remove('visible');
-    newSprintStartDateInput?.classList.remove('is-invalid');
-    newSprintEndDateInput?.classList.remove('is-invalid');
-    newSprintEndDateError?.classList.remove('visible');
 }
 
 document.getElementById('newSprintBtn').addEventListener('click', () => {
     if (newSprintNameInput) newSprintNameInput.value = '';
-    if (newSprintStartDateInput) newSprintStartDateInput.value = '';
-    if (newSprintEndDateInput) newSprintEndDateInput.value = '';
+    sprintDateRangePicker.reset();
     clearNewSprintValidation();
     if (newSprintModal) newSprintModal.style.display = 'flex';
 });
@@ -1133,14 +1146,6 @@ newSprintNameInput?.addEventListener('input', () => {
         newSprintNameError?.classList.remove('visible');
     }
 });
-
-function clearNewSprintDateError() {
-    newSprintStartDateInput?.classList.remove('is-invalid');
-    newSprintEndDateInput?.classList.remove('is-invalid');
-    newSprintEndDateError?.classList.remove('visible');
-}
-newSprintStartDateInput?.addEventListener('input', clearNewSprintDateError);
-newSprintEndDateInput?.addEventListener('input', clearNewSprintDateError);
 
 if (confirmNewSprintBtn) {
     confirmNewSprintBtn.addEventListener('click', async () => {
@@ -1154,15 +1159,7 @@ if (confirmNewSprintBtn) {
             return;
         }
 
-        const startDate = newSprintStartDateInput?.value || null;
-        const endDate = newSprintEndDateInput?.value || null;
-        if (startDate && endDate && endDate < startDate) {
-            newSprintStartDateInput?.classList.add('is-invalid');
-            newSprintEndDateInput?.classList.add('is-invalid');
-            newSprintEndDateError?.classList.add('visible');
-            newSprintEndDateInput?.focus();
-            return;
-        }
+        const { start: startDate, end: endDate } = sprintDateRangePicker.getRange();
 
         try {
             DOM.showLoading(true);

--- a/src/script.js
+++ b/src/script.js
@@ -1159,6 +1159,9 @@ if (confirmNewSprintBtn) {
             return;
         }
 
+        if (!sprintDateRangePicker.validate()) {
+            return;
+        }
         const { start: startDate, end: endDate } = sprintDateRangePicker.getRange();
 
         try {

--- a/src/script.js
+++ b/src/script.js
@@ -162,8 +162,10 @@ const requestVersionModalDescription = document.getElementById('requestVersionMo
 const confirmRequestVersionModalBtn = document.getElementById('confirmRequestVersionModalBtn');
 const newSprintModal = document.getElementById('newSprintModal');
 const newSprintNameInput = document.getElementById('newSprintNameInput');
+const newSprintNameError = document.getElementById('newSprintNameError');
 const newSprintStartDateInput = document.getElementById('newSprintStartDateInput');
 const newSprintEndDateInput = document.getElementById('newSprintEndDateInput');
+const newSprintEndDateError = document.getElementById('newSprintEndDateError');
 const confirmNewSprintBtn = document.getElementById('confirmNewSprintBtn');
 const prForm = document.getElementById('prForm');
 const profileScreen = document.getElementById('profileScreen');
@@ -1109,25 +1111,56 @@ if (monitorStatusBtn) {
 document.getElementById('logoutBtn').addEventListener('click', handleLogout);
 
 
+function clearNewSprintValidation() {
+    newSprintNameInput?.classList.remove('is-invalid');
+    newSprintNameError?.classList.remove('visible');
+    newSprintStartDateInput?.classList.remove('is-invalid');
+    newSprintEndDateInput?.classList.remove('is-invalid');
+    newSprintEndDateError?.classList.remove('visible');
+}
+
 document.getElementById('newSprintBtn').addEventListener('click', () => {
     if (newSprintNameInput) newSprintNameInput.value = '';
     if (newSprintStartDateInput) newSprintStartDateInput.value = '';
     if (newSprintEndDateInput) newSprintEndDateInput.value = '';
+    clearNewSprintValidation();
     if (newSprintModal) newSprintModal.style.display = 'flex';
 });
 
+newSprintNameInput?.addEventListener('input', () => {
+    if (newSprintNameInput.value.trim()) {
+        newSprintNameInput.classList.remove('is-invalid');
+        newSprintNameError?.classList.remove('visible');
+    }
+});
+
+function clearNewSprintDateError() {
+    newSprintStartDateInput?.classList.remove('is-invalid');
+    newSprintEndDateInput?.classList.remove('is-invalid');
+    newSprintEndDateError?.classList.remove('visible');
+}
+newSprintStartDateInput?.addEventListener('input', clearNewSprintDateError);
+newSprintEndDateInput?.addEventListener('input', clearNewSprintDateError);
+
 if (confirmNewSprintBtn) {
     confirmNewSprintBtn.addEventListener('click', async () => {
+        clearNewSprintValidation();
+
         const sprintName = newSprintNameInput?.value.trim();
         if (!sprintName) {
-            DOM.showToast('Informe o nome da sprint.', 'warning');
+            newSprintNameInput?.classList.add('is-invalid');
+            newSprintNameError?.classList.add('visible');
+            newSprintNameInput?.focus();
             return;
         }
 
         const startDate = newSprintStartDateInput?.value || null;
         const endDate = newSprintEndDateInput?.value || null;
         if (startDate && endDate && endDate < startDate) {
-            DOM.showToast('Data de término não pode ser antes da data de início.', 'warning');
+            newSprintStartDateInput?.classList.add('is-invalid');
+            newSprintEndDateInput?.classList.add('is-invalid');
+            newSprintEndDateError?.classList.add('visible');
+            newSprintEndDateInput?.focus();
             return;
         }
 

--- a/src/script.js
+++ b/src/script.js
@@ -1147,6 +1147,16 @@ newSprintNameInput?.addEventListener('input', () => {
     }
 });
 
+// Esc fecha o modal de Nova Sprint (não usamos o enableEscapeToCloseModals global porque o
+// index.html tem modais bloqueantes de propósito — login e seleção de tenant). Quando o
+// calendário está aberto, ele consome o Esc primeiro (stopPropagation no dateRangePicker)
+// e este handler nem roda: o primeiro Esc fecha o calendário, o segundo fecha o modal.
+document.addEventListener('keydown', (e) => {
+    if (e.key !== 'Escape') return;
+    if (newSprintModal?.style.display !== 'flex') return;
+    closeAllModals();
+});
+
 if (confirmNewSprintBtn) {
     confirmNewSprintBtn.addEventListener('click', async () => {
         clearNewSprintValidation();

--- a/src/script.js
+++ b/src/script.js
@@ -160,6 +160,11 @@ const requestVersionModal = document.getElementById('requestVersionModal');
 const requestVersionDevSelect = document.getElementById('requestVersionDevSelect');
 const requestVersionModalDescription = document.getElementById('requestVersionModalDescription');
 const confirmRequestVersionModalBtn = document.getElementById('confirmRequestVersionModalBtn');
+const newSprintModal = document.getElementById('newSprintModal');
+const newSprintNameInput = document.getElementById('newSprintNameInput');
+const newSprintStartDateInput = document.getElementById('newSprintStartDateInput');
+const newSprintEndDateInput = document.getElementById('newSprintEndDateInput');
+const confirmNewSprintBtn = document.getElementById('confirmNewSprintBtn');
 const prForm = document.getElementById('prForm');
 const profileScreen = document.getElementById('profileScreen');
 const currentUserDisplay = document.getElementById('currentUserDisplay');
@@ -431,6 +436,7 @@ function closeAllModals() {
     if (setupModal) setupModal.style.display = 'none';
     if (shortcutsModal) shortcutsModal.style.display = 'none';
     if (requestVersionModal) requestVersionModal.style.display = 'none';
+    if (newSprintModal) newSprintModal.style.display = 'none';
     pendingVersionRequestContext = null;
     
     if (LocalStorage.getItem('appUser')) {
@@ -1103,17 +1109,33 @@ if (monitorStatusBtn) {
 document.getElementById('logoutBtn').addEventListener('click', handleLogout);
 
 
-document.getElementById('newSprintBtn').addEventListener('click', async () => {
-    const sprintName = prompt('Informe o nome da nova Sprint (ex: 28):', 'Sprint ');
-    if (sprintName && sprintName.trim() !== 'Sprint ') {
+document.getElementById('newSprintBtn').addEventListener('click', () => {
+    if (newSprintNameInput) newSprintNameInput.value = '';
+    if (newSprintStartDateInput) newSprintStartDateInput.value = '';
+    if (newSprintEndDateInput) newSprintEndDateInput.value = '';
+    if (newSprintModal) newSprintModal.style.display = 'flex';
+});
+
+if (confirmNewSprintBtn) {
+    confirmNewSprintBtn.addEventListener('click', async () => {
+        const sprintName = newSprintNameInput?.value.trim();
+        if (!sprintName) {
+            DOM.showToast('Informe o nome da sprint.', 'warning');
+            return;
+        }
+
+        const startDate = newSprintStartDateInput?.value || null;
+        const endDate = newSprintEndDateInput?.value || null;
+        if (startDate && endDate && endDate < startDate) {
+            DOM.showToast('Data de término não pode ser antes da data de início.', 'warning');
+            return;
+        }
+
         try {
             DOM.showLoading(true);
-            const sprintData = {
-                name: sprintName
-            };
-
-            await API.createSprint(sprintData);
+            await API.createSprint({ name: sprintName, startDate, endDate });
             DOM.showToast(`Sprint "${sprintName}" criada com sucesso e definida como ativa!`);
+            closeAllModals();
             await loadData(true);
         } catch (error) {
             console.error('Erro ao criar sprint:', error);
@@ -1121,8 +1143,8 @@ document.getElementById('newSprintBtn').addEventListener('click', async () => {
         } finally {
             DOM.showLoading(false);
         }
-    }
-});
+    });
+}
 
 window.approvePr = async (prId) => {
     if (!prId) return;

--- a/src/style.css
+++ b/src/style.css
@@ -3072,6 +3072,28 @@ input:focus, select:focus {
   box-shadow: 0 0 0 2px var(--accent-glow);
 }
 
+/* Validação inline de formulário (preferencias.md §12): borda vermelha + texto no
+   próprio campo, em vez de só um toast genérico depois de bater na API. */
+input.is-invalid, select.is-invalid, textarea.is-invalid {
+  border-color: var(--danger-color);
+}
+
+input.is-invalid:focus, select.is-invalid:focus, textarea.is-invalid:focus {
+  border-color: var(--danger-color);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--danger-color) 35%, transparent);
+}
+
+.field-error {
+  display: none;
+  margin-top: 0.35rem;
+  font-size: 0.8rem;
+  color: var(--danger-color);
+}
+
+.field-error.visible {
+  display: block;
+}
+
 /* Loading Spinner */
 .loader {
   width: 48px;

--- a/src/style.css
+++ b/src/style.css
@@ -3094,6 +3094,176 @@ input.is-invalid:focus, select.is-invalid:focus, textarea.is-invalid:focus {
   display: block;
 }
 
+/* Componente de período (data início/fim) — issue pr-manager-cloud#18. Calendário único
+   em popover ancorado no campo, seguindo o mesmo padrão de diálogo customizado do resto
+   do projeto (markup estático + JS liga os elementos, ver src/dateRangePicker.js). */
+.date-range-field {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.date-range-field input {
+  flex: 1;
+  min-width: 0;
+}
+
+.date-range-arrow {
+  width: 16px;
+  height: 16px;
+  color: var(--text-secondary);
+  flex-shrink: 0;
+}
+
+.date-range-calendar-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  padding: 0.3rem;
+  color: var(--text-secondary);
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.date-range-calendar-btn:hover {
+  color: var(--accent-color);
+}
+
+.date-range-calendar-btn svg {
+  width: 18px;
+  height: 18px;
+}
+
+.date-range-popover {
+  display: none;
+  position: absolute;
+  top: calc(100% + 0.5rem);
+  left: 0;
+  z-index: 20;
+  width: 280px;
+  background: var(--card-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  padding: 1rem;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
+}
+
+.date-range-popover.open {
+  display: block;
+}
+
+.date-range-popover-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.6rem;
+}
+
+.date-range-nav-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  padding: 0.2rem;
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+
+.date-range-nav-btn:hover {
+  color: var(--accent-color);
+}
+
+.date-range-nav-btn svg {
+  width: 18px;
+  height: 18px;
+}
+
+.date-range-month-label {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  text-transform: capitalize;
+}
+
+.date-range-weekdays {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  text-align: center;
+  font-size: 0.7rem;
+  color: var(--text-secondary);
+  margin-bottom: 0.25rem;
+}
+
+.date-range-days {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 2px;
+}
+
+.date-range-day {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  aspect-ratio: 1;
+  border-radius: 50%;
+  font-size: 0.8rem;
+  color: var(--text-primary);
+  background: transparent;
+  cursor: pointer;
+  user-select: none;
+}
+
+.date-range-day:hover {
+  background: var(--accent-glow);
+}
+
+.date-range-day.is-other-month {
+  color: var(--text-secondary);
+  opacity: 0.4;
+  pointer-events: none;
+}
+
+.date-range-day.is-today {
+  border: 1px solid var(--accent-color);
+}
+
+.date-range-day.in-range {
+  background: var(--accent-glow);
+  border-radius: 0;
+}
+
+.date-range-day.is-start,
+.date-range-day.is-end {
+  background: var(--accent-color);
+  color: #fff;
+}
+
+.date-range-summary {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 0.75rem;
+  padding-top: 0.75rem;
+  border-top: 1px solid var(--border-color);
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+}
+
+.date-range-summary strong {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+.date-range-popover-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin-top: 0.85rem;
+}
+
 /* Loading Spinner */
 .loader {
   width: 48px;


### PR DESCRIPTION
## Resumo
- Causa raiz: o botão "Nova Sprint" usava `window.prompt()` para pedir o nome da sprint. Diálogos nativos (`prompt`/`confirm`/`alert`) bloqueiam totalmente o event loop da página enquanto abertos — em alguns contextos (extensões de automação, certas condições do navegador) esse bloqueio não é liberado, travando a aba inteira (cliques, screenshots e até o console param de responder), exatamente como descrito na issue.
- Segue a mesma convenção já usada em `apps.html`/`tenants.html`/`usuarios.html`, que trocaram `confirm()`/`alert()` nativos por diálogos em UI.
- Fix: novo modal `#newSprintModal` (mesmo padrão visual de `requestVersionModal`) com os campos que `CreateSprintDto` já aceita no backend — nome (obrigatório) e datas de início/término (opcionais) — sem necessidade de mudança de backend.
- Validações no cliente: nome vazio bloqueia o envio (toast de aviso, modal permanece aberto); data de término anterior à de início também bloqueia.

## Nota sobre débito técnico maior
Durante a investigação encontrei bem mais chamadas de `confirm()`/`alert()` nativos espalhadas por `src/script.js` e outros módulos (logout, aprovar PR, arquivar PR, lotes de versão, etc.) — o mesmo anti-padrão, só que fora do escopo desta issue especifica (que trata só do botão "Nova Sprint"). Vale considerar uma task futura para migrar os demais casos para diálogos em UI, seguindo o padrão já estabelecido em `apps.html`/`tenants.html`/`usuarios.html`.

## Plano de teste
- [x] Clicar em "Nova Sprint" abre o modal em vez de travar a página.
- [x] Criar sprint só com nome funciona (toast de sucesso, sprint definida como ativa).
- [x] Nome vazio: toast de aviso "Informe o nome da sprint", modal continua aberto.
- [x] Botão "Cancelar" fecha o modal sem chamar a API.

Issue: https://github.com/SamuelAraag/pr-manager-cloud/issues/18