### PR TITLE
Confirma arquivamento de PR por modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -464,6 +464,21 @@
         </div>
     </div>
 
+    <!-- Confirmação contextual para arquivamento de PR (sem confirm() nativo). -->
+    <div id="confirmDialog" class="modal-overlay" role="dialog" aria-modal="true"
+        aria-labelledby="confirmDialogTitle" aria-describedby="confirmDialogMessage" aria-hidden="true">
+        <div class="modal-content" style="max-width: 420px;">
+            <div class="modal-header">
+                <h2 id="confirmDialogTitle">Arquivar PR</h2>
+            </div>
+            <p id="confirmDialogMessage" style="color: var(--text-secondary);"></p>
+            <div class="module-form-actions">
+                <button id="confirmDialogNo" class="btn btn-outline" type="button">Cancelar</button>
+                <button id="confirmDialogYes" class="btn btn-danger" type="button">Arquivar PR</button>
+            </div>
+        </div>
+    </div>
+
     <!-- Toast Notifications Container -->
     <div id="toast-container" class="toast-container"></div>
 

--- a/src/domService.js
+++ b/src/domService.js
@@ -173,7 +173,7 @@ function showToast(message, type = 'success', title = '', isRestored = false) {
 // Diálogo de confirmação em UI (00-principles.md proíbe confirm()/alert() nativos). Espera
 // os elementos #confirmDialog/#confirmDialogTitle/#confirmDialogMessage/#confirmDialogYes/
 // #confirmDialogNo na página (ver tenants.html). Resolve true/false, nunca rejeita.
-function confirmDialog(message, title = 'Confirmar ação') {
+function confirmDialog(message, title = 'Confirmar ação', options = {}) {
     return new Promise(resolve => {
         const overlay = document.getElementById('confirmDialog');
         if (!overlay) { resolve(window.confirm(message)); return; }
@@ -183,19 +183,57 @@ function confirmDialog(message, title = 'Confirmar ação') {
 
         const yesBtn = document.getElementById('confirmDialogYes');
         const noBtn = document.getElementById('confirmDialogNo');
+        const previouslyFocused = document.activeElement;
+        const confirmLabel = options.confirmLabel || 'Confirmar';
+
+        yesBtn.textContent = confirmLabel;
+        yesBtn.classList.toggle('btn-danger', options.danger === true);
+        yesBtn.classList.toggle('btn-primary', options.danger !== true);
 
         const cleanup = (result) => {
             overlay.style.display = 'none';
+            overlay.setAttribute('aria-hidden', 'true');
             yesBtn.removeEventListener('click', onYes);
             noBtn.removeEventListener('click', onNo);
+            overlay.removeEventListener('click', onOverlayClick);
+            document.removeEventListener('keydown', onKeyDown);
+
+            if (previouslyFocused instanceof HTMLElement && previouslyFocused.isConnected) {
+                previouslyFocused.focus({ preventScroll: true });
+            }
+
             resolve(result);
         };
         const onYes = () => cleanup(true);
         const onNo = () => cleanup(false);
+        const onOverlayClick = (event) => {
+            if (event.target === overlay) cleanup(false);
+        };
+        const onKeyDown = (event) => {
+            if (event.key === 'Escape') {
+                event.preventDefault();
+                cleanup(false);
+                return;
+            }
+
+            if (event.key !== 'Tab') return;
+
+            if (event.shiftKey && document.activeElement === noBtn) {
+                event.preventDefault();
+                yesBtn.focus();
+            } else if (!event.shiftKey && document.activeElement === yesBtn) {
+                event.preventDefault();
+                noBtn.focus();
+            }
+        };
 
         yesBtn.addEventListener('click', onYes);
         noBtn.addEventListener('click', onNo);
+        overlay.addEventListener('click', onOverlayClick);
+        document.addEventListener('keydown', onKeyDown);
+        overlay.setAttribute('aria-hidden', 'false');
         overlay.style.display = 'flex';
+        noBtn.focus({ preventScroll: true });
     });
 }
 

--- a/src/script.js
+++ b/src/script.js
@@ -1304,7 +1304,18 @@ window.togglePrHistory = async (prId) => {
 window.archivePr = async (prId) => {
     if (!prId) return;
 
-    if (!confirm('Tem certeza que deseja ARQUIVAR este PR? Ele sairá da lista de pendentes.')) {
+    const pr = currentData.prs.find(item => String(item.id) === String(prId));
+    const taskId = extractJiraId(pr?.taskLink);
+    const prDescription = [taskId, pr?.summary].filter(Boolean).join(' - ')
+        || pr?.project
+        || 'selecionado';
+    const confirmed = await DOM.confirmDialog(
+        `Arquivar o PR "${prDescription}"? Ele sairá da lista de pendentes.`,
+        'Arquivar PR',
+        { confirmLabel: 'Arquivar PR', danger: true }
+    );
+
+    if (!confirmed) {
         return;
     }
 


### PR DESCRIPTION
## Resumo
- substitui o diálogo nativo de confirmação ao arquivar um PR
- identifica o PR pelo código da task e resumo
- usa ação destrutiva com cancelamento por botão, clique externo e Esc
- move o foco para uma ação segura e o devolve ao elemento de origem ao fechar

## Verificação
- `git diff --check`
- `node --input-type=module --check < src/domService.js`
- `node --input-type=module --check < src/script.js`

Relacionado a https://github.com/SamuelAraag/pr-manager/issues/33