### PR TITLE
fix: autentica SignalR com JWT e remove endpoint anônimo de perfis

### DIFF
--- a/src/apiService.js
+++ b/src/apiService.js
@@ -107,18 +107,8 @@ async function fetchSprints() {
   }
 }
 
-// Perfis para a tela pré-login "Quem está editando?" (endpoint anônimo, sem email)
-async function fetchProfiles() {
-  const url = `${ApiConstants.BASE_URL}/Users/profiles`;
-  try {
-    const response = await fetch(url, { headers: getBackendHeaders(), cache: "no-store" });
-    if (!response.ok) return [];
-    return await response.json();
-  } catch (error) {
-    console.error("Falha ao buscar perfis:", error);
-    return [];
-  }
-}
+// Issue #34: fetchProfiles foi removido junto com GET /Users/profiles — era anônimo e
+// listava usuários de todos os tenants. A tela pré-login que o usava não existe mais.
 
 async function fetchUsers(includeInactive = false, global = false) {
   const params = new URLSearchParams();
@@ -892,7 +882,6 @@ export {
   saveAutomationConfig,
   adminLogin,
   login,
-  fetchProfiles,
   fetchApps,
   createApp,
   updateApp,

--- a/src/notificationService.js
+++ b/src/notificationService.js
@@ -3,6 +3,7 @@ import { ApiConstants, getDemoProject, getDemoName } from './constants/apiConsta
 import { initNotificationAudio } from './notificationAudioService.js';
 import { initBrowserNotifications, showBrowserNotification } from './browserNotificationService.js';
 import { refreshIcons } from './iconService.js';
+import { getItem } from './localStorageService.js';
 
 const STORAGE_KEY = 'pr_notifications';
 const UNREAD_KEY  = 'pr_notifications_unread';
@@ -185,12 +186,18 @@ export async function connectSignalR(onMessageReceived) {
     }
 
     const hubUrl = ApiConstants.BASE_URL.replace('/api', '/notificationHub');
-    const rawUserId = localStorage.getItem('appUserId');
-    const userId = rawUserId ? JSON.parse(rawUserId) : '';
-    const hubUrlWithUser = userId ? `${hubUrl}?userId=${userId}` : hubUrl;
+
+    // Issue #34: a identidade ia no ?userId= e o backend confiava nela — qualquer um entrava
+    // no grupo de qualquer usuário. Agora o hub exige JWT; o SignalR manda o token em
+    // ?access_token= (o WebSocket do navegador não aceita header Authorization).
+    const token = getItem('token');
+    if (!token) {
+        console.warn('Sem token: conexão de notificações não iniciada.');
+        return;
+    }
 
     connection = new signalR.HubConnectionBuilder()
-        .withUrl(hubUrlWithUser)
+        .withUrl(hubUrl, { accessTokenFactory: () => token })
         .withAutomaticReconnect([0, 2000, 5000, 10000, 30000, 60000])
         .build();
 

--- a/src/script.js
+++ b/src/script.js
@@ -664,17 +664,12 @@ function getVersionAssignableUsers() {
 }
 
 async function loadUsers() {
-    // Antes do login não há token: a tela "Quem está editando?" usa o endpoint
-    // anônimo de perfis (só ativos, sem email). Com token, usa a lista completa.
-    try {
-        let users = LocalStorage.getItem('token')
-            ? await API.fetchUsers()
-            : await API.fetchProfiles();
+    // Issue #34: sem token não há lista de usuários — o endpoint anônimo de perfis foi
+    // removido (vazava usuários de todos os tenants) e a tela de login já é e-mail + senha.
+    if (!LocalStorage.getItem('token')) return;
 
-        // token expirado/inválido → cai para o endpoint anônimo em vez de grade vazia
-        if (!Array.isArray(users) || users.length === 0) {
-            users = await API.fetchProfiles();
-        }
+    try {
+        const users = await API.fetchUsers();
 
         if (Array.isArray(users) && users.length > 0) {
             availableUsers = users;


### PR DESCRIPTION
Parte frontend da issue [#34 do pr-manager](https://github.com/SamuelAraag/pr-manager/issues/34) — fundação multi-tenant: autorização, vínculos e isolamento de dados.

Depende do PR de backend correspondente ([pr-manager#42](https://github.com/SamuelAraag/pr-manager/pull/42)): o hub passa a exigir JWT e `GET /Users/profiles` deixa de existir. Os dois devem ser mesclados juntos.

## O que muda

- **`notificationService.js`** — a conexão com o `/notificationHub` mandava a identidade em `?userId=`, e o backend confiava nela sem validar: qualquer cliente entrava no grupo de qualquer usuário e recebia as notificações dele. Agora usa `accessTokenFactory` (o hub exige JWT; o WebSocket do navegador não aceita header `Authorization`, daí o token ir na query). Sem token, a conexão não é iniciada.
- **`apiService.js`** — `fetchProfiles` removido junto com o endpoint `GET /Users/profiles`, que era anônimo e listava nome/avatar de usuários de **todos** os tenants para qualquer visitante.
- **`script.js`** — `loadUsers()` retorna cedo quando não há token, em vez de cair no endpoint anônimo. A tela pré-login "Quem está editando?" que consumia essa lista não existe mais: o login já é e-mail + senha.

## Plano de teste

1. Subir o app com o backend do PR correspondente e logar normalmente.
2. Confirmar que o sininho de notificações conecta (sem erro de handshake no console) e que uma ação em PR de outro usuário chega em tempo real.
3. Confirmar que, deslogado, nenhuma requisição a `/Users/profiles` é disparada e a tela de login funciona por e-mail + senha.
