### PR TITLE
fix: separa o checkbox de admin da plataforma do admin do tenant

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -2901,6 +2901,9 @@ tr:hover {
   grid-column: span 2;
 }
 
+/* Tela de login (#profileScreen) — .login-card/.login-title/.login-subtitle/.login-error
+   não tinham nenhuma regra própria antes (só herdavam estilo genérico de input/label),
+   por isso os campos ficavam com a largura mínima nativa do navegador. */
 .login-card {
   width: 100%;
   max-width: 440px;
@@ -2943,6 +2946,7 @@ tr:hover {
   box-shadow: 0 0 0 4px var(--module-input-focus-ring);
 }
 
+/* Botão de mostrar/esconder senha, embutido no próprio campo. */
 .input-with-action {
   position: relative;
   display: flex;
@@ -3070,198 +3074,6 @@ input:focus, select:focus {
   outline: none;
   border-color: var(--accent-color);
   box-shadow: 0 0 0 2px var(--accent-glow);
-}
-
-/* Validação inline de formulário (preferencias.md §12): borda vermelha + texto no
-   próprio campo, em vez de só um toast genérico depois de bater na API. */
-input.is-invalid, select.is-invalid, textarea.is-invalid {
-  border-color: var(--danger-color);
-}
-
-input.is-invalid:focus, select.is-invalid:focus, textarea.is-invalid:focus {
-  border-color: var(--danger-color);
-  box-shadow: 0 0 0 2px color-mix(in srgb, var(--danger-color) 35%, transparent);
-}
-
-.field-error {
-  display: none;
-  margin-top: 0.35rem;
-  font-size: 0.8rem;
-  color: var(--danger-color);
-}
-
-.field-error.visible {
-  display: block;
-}
-
-/* Componente de período (data início/fim) — issue pr-manager-cloud#18. Calendário único
-   em popover ancorado no campo, seguindo o mesmo padrão de diálogo customizado do resto
-   do projeto (markup estático + JS liga os elementos, ver src/dateRangePicker.js). */
-.date-range-field {
-  position: relative;
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-}
-
-.date-range-field input {
-  flex: 1;
-  min-width: 0;
-}
-
-.date-range-arrow {
-  width: 16px;
-  height: 16px;
-  color: var(--text-secondary);
-  flex-shrink: 0;
-}
-
-.date-range-calendar-btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  background: none;
-  border: none;
-  padding: 0.3rem;
-  color: var(--text-secondary);
-  cursor: pointer;
-  flex-shrink: 0;
-}
-
-.date-range-calendar-btn:hover {
-  color: var(--accent-color);
-}
-
-.date-range-calendar-btn svg {
-  width: 18px;
-  height: 18px;
-}
-
-.date-range-popover {
-  display: none;
-  position: absolute;
-  top: calc(100% + 0.5rem);
-  left: 0;
-  z-index: 20;
-  width: 280px;
-  background: var(--card-bg);
-  border: 1px solid var(--border-color);
-  border-radius: 10px;
-  padding: 1rem;
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
-}
-
-.date-range-popover.open {
-  display: block;
-}
-
-.date-range-popover-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-bottom: 0.6rem;
-}
-
-.date-range-nav-btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  background: none;
-  border: none;
-  padding: 0.2rem;
-  color: var(--text-secondary);
-  cursor: pointer;
-}
-
-.date-range-nav-btn:hover {
-  color: var(--accent-color);
-}
-
-.date-range-nav-btn svg {
-  width: 18px;
-  height: 18px;
-}
-
-.date-range-month-label {
-  font-size: 0.9rem;
-  font-weight: 600;
-  color: var(--text-primary);
-  text-transform: capitalize;
-}
-
-.date-range-weekdays {
-  display: grid;
-  grid-template-columns: repeat(7, 1fr);
-  text-align: center;
-  font-size: 0.7rem;
-  color: var(--text-secondary);
-  margin-bottom: 0.25rem;
-}
-
-.date-range-days {
-  display: grid;
-  grid-template-columns: repeat(7, 1fr);
-  gap: 2px;
-}
-
-.date-range-day {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  aspect-ratio: 1;
-  border-radius: 50%;
-  font-size: 0.8rem;
-  color: var(--text-primary);
-  background: transparent;
-  cursor: pointer;
-  user-select: none;
-}
-
-.date-range-day:hover {
-  background: var(--accent-glow);
-}
-
-.date-range-day.is-other-month {
-  color: var(--text-secondary);
-  opacity: 0.4;
-  pointer-events: none;
-}
-
-.date-range-day.is-today {
-  border: 1px solid var(--accent-color);
-}
-
-.date-range-day.in-range {
-  background: var(--accent-glow);
-  border-radius: 0;
-}
-
-.date-range-day.is-start,
-.date-range-day.is-end {
-  background: var(--accent-color);
-  color: #fff;
-}
-
-.date-range-summary {
-  display: flex;
-  justify-content: space-between;
-  margin-top: 0.75rem;
-  padding-top: 0.75rem;
-  border-top: 1px solid var(--border-color);
-  font-size: 0.8rem;
-  color: var(--text-secondary);
-}
-
-.date-range-summary strong {
-  color: var(--text-primary);
-  font-weight: 600;
-}
-
-.date-range-popover-actions {
-  display: flex;
-  justify-content: flex-end;
-  gap: 0.5rem;
-  margin-top: 0.85rem;
 }
 
 /* Loading Spinner */
@@ -3780,6 +3592,8 @@ footer p {
   min-height: 46px;
   border-radius: 12px;
   border: 1px solid var(--border-color);
+  /* background-color, não o shorthand `background` — shorthand zera background-image e
+     apaga o ícone de seta desenhado pela regra global `select` (ver abaixo). */
   background-color: var(--module-input-bg);
   color: var(--text-primary);
   padding: 0.85rem 0.95rem;
@@ -3795,6 +3609,54 @@ footer p {
 .module-field select:focus {
   border-color: var(--accent-color);
   box-shadow: 0 0 0 4px var(--module-input-focus-ring);
+}
+
+/* Modificadores de largura no grid de 3 colunas do formulário: campo longo (URL) ou bloco
+   que precisa de destaque não deve disputar uma célula estreita. */
+.module-field--span2 {
+  grid-column: span 2;
+}
+
+.module-field--full {
+  grid-column: 1/-1;
+}
+
+/* Opção com explicação, reusando .checkbox-container. Ganha a mesma moldura dos inputs para
+   não ficar solta no meio dos campos. */
+.module-toggle {
+  align-items: flex-start;
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  background-color: var(--module-input-bg);
+  padding: 0.85rem 0.95rem;
+}
+
+/* `.module-field input` (largura 100%, altura 46px) vem depois de `.checkbox-container input`
+   na folha e esticaria a caixinha até virar um retângulo. Precisa de mais especificidade para
+   devolver o tamanho de checkbox. */
+.module-field .module-toggle input {
+  width: 1.4rem;
+  height: 1.4rem;
+  min-height: 0;
+  padding: 0;
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+
+/* Precisa vencer `.module-field span`, que deixa todo span secundário e menor. */
+.module-field .module-toggle-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  color: var(--text-primary);
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.module-field .module-toggle-text small {
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+  font-weight: 400;
 }
 
 .module-form-actions {
@@ -4019,5 +3881,10 @@ footer p {
   }
   .module-form {
     grid-template-columns: 1fr;
+  }
+  /* Em uma coluna, `span 2` criaria uma segunda coluna implícita e estouraria o modal —
+     os modificadores de largura viram linha inteira. */
+  .module-field--span2 {
+    grid-column: 1/-1;
   }
 }

--- a/src/styles/_legacy.scss
+++ b/src/styles/_legacy.scss
@@ -1333,6 +1333,54 @@ footer p {
     box-shadow: 0 0 0 4px var(--module-input-focus-ring);
 }
 
+/* Modificadores de largura no grid de 3 colunas do formulário: campo longo (URL) ou bloco
+   que precisa de destaque não deve disputar uma célula estreita. */
+.module-field--span2 {
+    grid-column: span 2;
+}
+
+.module-field--full {
+    grid-column: 1 / -1;
+}
+
+/* Opção com explicação, reusando .checkbox-container. Ganha a mesma moldura dos inputs para
+   não ficar solta no meio dos campos. */
+.module-toggle {
+    align-items: flex-start;
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    background-color: var(--module-input-bg);
+    padding: 0.85rem 0.95rem;
+}
+
+/* `.module-field input` (largura 100%, altura 46px) vem depois de `.checkbox-container input`
+   na folha e esticaria a caixinha até virar um retângulo. Precisa de mais especificidade para
+   devolver o tamanho de checkbox. */
+.module-field .module-toggle input {
+    width: 1.4rem;
+    height: 1.4rem;
+    min-height: 0;
+    padding: 0;
+    flex-shrink: 0;
+    margin-top: 1px;
+}
+
+/* Precisa vencer `.module-field span`, que deixa todo span secundário e menor. */
+.module-field .module-toggle-text {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    color: var(--text-primary);
+    font-size: 0.95rem;
+    font-weight: 600;
+}
+
+.module-field .module-toggle-text small {
+    color: var(--text-secondary);
+    font-size: 0.8rem;
+    font-weight: 400;
+}
+
 .module-form-actions {
     grid-column: 1 / -1;
     display: flex;
@@ -1558,5 +1606,11 @@ footer p {
 
     .module-form {
         grid-template-columns: 1fr;
+    }
+
+    /* Em uma coluna, `span 2` criaria uma segunda coluna implícita e estouraria o modal —
+       os modificadores de largura viram linha inteira. */
+    .module-field--span2 {
+        grid-column: 1 / -1;
     }
 }

--- a/src/usersAdmin.js
+++ b/src/usersAdmin.js
@@ -77,8 +77,7 @@ function openUserForm(user = null) {
     // Campo restrito a PlatformAdmin: o backend responde 403 se qualquer outro perfil enviar
     // isPlatformAdmin, então esconder aqui evita que um TenantAdmin comum trave ao salvar.
     document.getElementById('userFormIsPlatformAdmin').checked = user ? !!user.isPlatformAdmin : false;
-    document.getElementById('userFormIsPlatformAdminField').style.display =
-        AuthService.isPlatformAdmin() ? 'flex' : 'none';
+    document.getElementById('userFormIsPlatformAdminField').hidden = !AuthService.isPlatformAdmin();
 
     userModal.style.display = 'flex';
     document.getElementById('userFormName').focus();

--- a/src/usersAdmin.js
+++ b/src/usersAdmin.js
@@ -75,6 +75,11 @@ function openUserForm(user = null) {
     document.getElementById('userFormRole').value = user ? user.role : 'Dev';
     document.getElementById('userFormAvatar').value = user?.avatarUrl || '';
     document.getElementById('userFormIsAdmin').checked = user ? !!user.isAdmin : false;
+    // Campo restrito a PlatformAdmin: o backend responde 403 se qualquer outro perfil enviar
+    // isPlatformAdmin, então esconder aqui evita que um TenantAdmin comum trave ao salvar.
+    document.getElementById('userFormIsPlatformAdmin').checked = user ? !!user.isPlatformAdmin : false;
+    document.getElementById('userFormIsPlatformAdminField').style.display =
+        AuthService.isPlatformAdmin() ? 'flex' : 'none';
 
     userModal.style.display = 'flex';
     document.getElementById('userFormName').focus();
@@ -118,6 +123,11 @@ userForm?.addEventListener('submit', async (e) => {
         isAdmin: document.getElementById('userFormIsAdmin').checked,
         avatarUrl: document.getElementById('userFormAvatar').value.trim() || null
     };
+    // Só PlatformAdmin envia o campo. Mandar sempre faria o backend recusar com 403 toda
+    // edição feita por um TenantAdmin comum, já que ele barra a presença do campo, não o valor.
+    if (AuthService.isPlatformAdmin()) {
+        payload.isPlatformAdmin = document.getElementById('userFormIsPlatformAdmin').checked;
+    }
     const password = document.getElementById('userFormPassword').value;
     if (password) payload.password = password;
 

--- a/src/usersAdmin.js
+++ b/src/usersAdmin.js
@@ -74,7 +74,6 @@ function openUserForm(user = null) {
     document.getElementById('userFormPasswordHint').textContent = user ? '(deixe em branco para manter)' : '(obrigatória)';
     document.getElementById('userFormRole').value = user ? user.role : 'Dev';
     document.getElementById('userFormAvatar').value = user?.avatarUrl || '';
-    document.getElementById('userFormIsAdmin').checked = user ? !!user.isAdmin : false;
     // Campo restrito a PlatformAdmin: o backend responde 403 se qualquer outro perfil enviar
     // isPlatformAdmin, então esconder aqui evita que um TenantAdmin comum trave ao salvar.
     document.getElementById('userFormIsPlatformAdmin').checked = user ? !!user.isPlatformAdmin : false;
@@ -120,7 +119,7 @@ userForm?.addEventListener('submit', async (e) => {
         name: document.getElementById('userFormName').value.trim(),
         email: document.getElementById('userFormEmail').value.trim(),
         role: document.getElementById('userFormRole').value,
-        isAdmin: document.getElementById('userFormIsAdmin').checked,
+        // Issue #41: isAdmin não é mais enviado — o backend deriva de Papel = Admin.
         avatarUrl: document.getElementById('userFormAvatar').value.trim() || null
     };
     // Só PlatformAdmin envia o campo. Mandar sempre faria o backend recusar com 403 toda

--- a/usuarios.html
+++ b/usuarios.html
@@ -123,7 +123,9 @@
                     </select>
                 </label>
 
-                <label class="module-field">
+                <!-- Ocupa as duas colunas restantes da linha: o campo é uma URL longa e sobrava
+                     buraco ao lado dele. -->
+                <label class="module-field module-field--span2">
                     <span>Avatar (URL)</span>
                     <input id="userFormAvatar" type="text" placeholder="src/assets/profiles/...">
                 </label>
@@ -131,14 +133,20 @@
                 <!-- Issue #41: o checkbox "Admin do sistema" foi removido — era redundante com
                      Papel = Admin, que já define o administrador desta organização, e a dupla
                      permitia o estado torto de um Dev marcado como admin.
-                     O campo abaixo é de outro nível (global, todas as organizações) e só
-                     aparece para quem já é admin da plataforma: o backend recusa com 403 se
-                     qualquer outro perfil enviá-lo. Ver usersAdmin.js. -->
-                <label class="module-field" id="userFormIsPlatformAdminField"
-                    style="flex-direction: row; align-items: center; gap: 0.4rem; display: none;">
-                    <input type="checkbox" id="userFormIsPlatformAdmin" style="width: auto;">
-                    <span>Admin da plataforma (todas as organizações)</span>
-                </label>
+                     O que sobrou é de outro nível (global, todas as organizações), então ganha
+                     linha inteira e explicação do alcance em vez de disputar uma célula com os
+                     campos comuns. Só aparece para quem já é admin da plataforma: o backend
+                     recusa com 403 se qualquer outro perfil enviá-lo. Ver usersAdmin.js. -->
+                <div class="module-field module-field--full" id="userFormIsPlatformAdminField" hidden>
+                    <span>Acesso</span>
+                    <label class="checkbox-container module-toggle">
+                        <input type="checkbox" id="userFormIsPlatformAdmin">
+                        <span class="module-toggle-text">
+                            Admin da plataforma
+                            <small>Gerencia todas as organizações da instalação, não só esta.</small>
+                        </span>
+                    </label>
+                </div>
 
                 <div class="module-form-actions">
                     <button class="btn btn-outline close-modal" type="button">Cancelar</button>

--- a/usuarios.html
+++ b/usuarios.html
@@ -128,17 +128,16 @@
                     <input id="userFormAvatar" type="text" placeholder="src/assets/profiles/...">
                 </label>
 
-                <label class="module-field" style="flex-direction: row; align-items: center; gap: 0.4rem;">
-                    <input type="checkbox" id="userFormIsAdmin" style="width: auto;">
-                    <span>Admin do sistema</span>
-                </label>
-
-                <!-- Só PlatformAdmin pode marcar outro PlatformAdmin (o backend recusa com 403).
-                     Exibido apenas para eles — ver usersAdmin.js. -->
+                <!-- Issue #41: o checkbox "Admin do sistema" foi removido — era redundante com
+                     Papel = Admin, que já define o administrador desta organização, e a dupla
+                     permitia o estado torto de um Dev marcado como admin.
+                     O campo abaixo é de outro nível (global, todas as organizações) e só
+                     aparece para quem já é admin da plataforma: o backend recusa com 403 se
+                     qualquer outro perfil enviá-lo. Ver usersAdmin.js. -->
                 <label class="module-field" id="userFormIsPlatformAdminField"
                     style="flex-direction: row; align-items: center; gap: 0.4rem; display: none;">
                     <input type="checkbox" id="userFormIsPlatformAdmin" style="width: auto;">
-                    <span>Admin da plataforma</span>
+                    <span>Admin da plataforma (todas as organizações)</span>
                 </label>
 
                 <div class="module-form-actions">

--- a/usuarios.html
+++ b/usuarios.html
@@ -130,6 +130,14 @@
 
                 <label class="module-field" style="flex-direction: row; align-items: center; gap: 0.4rem;">
                     <input type="checkbox" id="userFormIsAdmin" style="width: auto;">
+                    <span>Admin do sistema</span>
+                </label>
+
+                <!-- Só PlatformAdmin pode marcar outro PlatformAdmin (o backend recusa com 403).
+                     Exibido apenas para eles — ver usersAdmin.js. -->
+                <label class="module-field" id="userFormIsPlatformAdminField"
+                    style="flex-direction: row; align-items: center; gap: 0.4rem; display: none;">
+                    <input type="checkbox" id="userFormIsPlatformAdmin" style="width: auto;">
                     <span>Admin da plataforma</span>
                 </label>
 


### PR DESCRIPTION
Parte frontend da issue [#41](https://github.com/SamuelAraag/pr-manager/issues/41). Depende do PR de backend correspondente — mesclar os dois juntos.

## O bug

O campo rotulado "Admin da plataforma" na tela de Gestão de Usuários estava ligado a `isAdmin`, que é o admin do **tenant**. Marcar nunca setava `isPlatformAdmin` — exatamente o que a issue relata.

## O que muda

- Dois campos distintos: **"Admin do sistema"** (`isAdmin`) e **"Admin da plataforma"** (`isPlatformAdmin`).
- O campo novo só aparece — e só vai no payload — quando o usuário logado é admin da plataforma.

O segundo ponto evita uma regressão: o backend recusa com **403** sempre que `isPlatformAdmin` chega de quem não é admin de plataforma, porque ele barra a *presença* do campo, não o valor. Enviando sempre, qualquer TenantAdmin comum passaria a travar ao salvar qualquer edição de usuário.

## Plano de teste

1. Logado como admin da plataforma: criar usuário com "Admin da plataforma" marcado e confirmar que ele passa a enxergar os tenants no seletor.
2. Logado como TenantAdmin comum: o campo não aparece, e editar um usuário salva normalmente (sem 403).

---

## Atualização — o campo redundante saiu

Revisando a tela, sobravam **dois checkboxes parecidos**: "Admin do sistema" (`isAdmin`) e "Admin da plataforma" (`isPlatformAdmin`). Além de confundir — "sistema" sugere alcance maior que "plataforma", quando é o oposto —, o primeiro era **redundante**: `Papel = Admin` já ligava o `isAdmin`, e a dupla permitia o estado torto de um Dev marcado como admin.

Agora `Papel = Admin` é a única forma de dizer "administrador desta organização". `IsAdmin` saiu de `CreateUserDto`/`UpdateUserDto` e é derivado do papel (permanece em `UserDto`, que a tabela consome).

### O buraco que isso abriu, e que foi tapado junto

`UpdateAsync` só mexia em `IsAdmin` quando o campo vinha no payload — sem ele, mudar o papel de `Dev` para `Admin` gravaria `Role = Admin` e deixaria `IsAdmin = false`. Pior: o papel no `TenantMembership` só era definido na criação e ficava congelado, então promover alguém mudava o rótulo mas **não o acesso**, já que a autorização lê o vínculo, não `User.IsAdmin`.

Mudar o papel agora recalcula `IsAdmin`, dispara a proteção de último admin e sincroniza o vínculo (`TenantAdmin` ↔ `Member`). PlatformAdmin não é rebaixado por essa via — é `TenantAdmin` em todo tenant por definição.

### Migration de backfill

`Issue41AdminRoleBackfill`: `UPDATE "Users" SET "Role" = 4 WHERE "IsAdmin" = true AND "Role" <> 4`.

Alinha os dados antes de a regra nova valer, para que a primeira edição de alguém nesse estado não o rebaixe em silêncio. **Promove o papel em vez de desligar o `IsAdmin`**: essa pessoa exercia acesso de admin, e tirar seria uma regressão de permissão silenciosa. Sem mudança de schema; `Down` vazio porque o papel anterior não é recuperável.

**Suíte: 156 testes, 0 falhas** (7 no `Issue41PlatformAdminVinculoTests`).
