### PR TITLE
style: usa cor chapada nos títulos das páginas + restaura CSS perdido no build

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -643,20 +643,6 @@ function updateUserDisplay(userName) {
     if (orgsBtn) {
         orgsBtn.style.display = AuthService.isPlatformAdmin() ? 'inline-flex' : 'none';
     }
-
-    const appTitle = document.getElementById('appTitle');
-    if (appTitle) {
-        if (isAdmin) {
-            appTitle.style.background = 'none';
-            appTitle.style.webkitTextFillColor = 'var(--accent-color)';
-            appTitle.style.color = 'var(--accent-color)';
-        } else {
-            appTitle.style.background = 'linear-gradient(90deg, var(--accent-color), color-mix(in srgb, var(--accent-color) 72%, white))';
-            appTitle.style.webkitBackgroundClip = 'text';
-            appTitle.style.backgroundClip = 'text';
-            appTitle.style.webkitTextFillColor = 'transparent';
-        }
-    }
 }
 
 function getVersionAssignableUsers() {

--- a/src/style.css
+++ b/src/style.css
@@ -2255,10 +2255,7 @@ header {
 h1 {
   font-size: 2rem;
   font-weight: 700;
-  background: linear-gradient(90deg, var(--accent-color), color-mix(in srgb, var(--accent-color) 72%, white));
-  -webkit-background-clip: text;
-  background-clip: text;
-  -webkit-text-fill-color: transparent;
+  color: var(--accent-color);
 }
 
 .btn {
@@ -2360,8 +2357,6 @@ h1 {
   margin-bottom: 3rem;
   font-size: 2.5rem;
   color: white;
-  background: none;
-  -webkit-text-fill-color: initial;
 }
 
 .profiles-grid {

--- a/src/style.css
+++ b/src/style.css
@@ -3071,6 +3071,198 @@ input:focus, select:focus {
   box-shadow: 0 0 0 2px var(--accent-glow);
 }
 
+/* Validação inline de formulário (preferencias.md §12): borda vermelha + texto no
+   próprio campo, em vez de só um toast genérico depois de bater na API. */
+input.is-invalid, select.is-invalid, textarea.is-invalid {
+  border-color: var(--danger-color);
+}
+
+input.is-invalid:focus, select.is-invalid:focus, textarea.is-invalid:focus {
+  border-color: var(--danger-color);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--danger-color) 35%, transparent);
+}
+
+.field-error {
+  display: none;
+  margin-top: 0.35rem;
+  font-size: 0.8rem;
+  color: var(--danger-color);
+}
+
+.field-error.visible {
+  display: block;
+}
+
+/* Componente de período (data início/fim) — issue pr-manager-cloud#18. Calendário único
+   em popover ancorado no campo, seguindo o mesmo padrão de diálogo customizado do resto
+   do projeto (markup estático + JS liga os elementos, ver src/dateRangePicker.js). */
+.date-range-field {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.date-range-field input {
+  flex: 1;
+  min-width: 0;
+}
+
+.date-range-arrow {
+  width: 16px;
+  height: 16px;
+  color: var(--text-secondary);
+  flex-shrink: 0;
+}
+
+.date-range-calendar-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  padding: 0.3rem;
+  color: var(--text-secondary);
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.date-range-calendar-btn:hover {
+  color: var(--accent-color);
+}
+
+.date-range-calendar-btn svg {
+  width: 18px;
+  height: 18px;
+}
+
+.date-range-popover {
+  display: none;
+  position: absolute;
+  top: calc(100% + 0.5rem);
+  left: 0;
+  z-index: 20;
+  width: 280px;
+  background: var(--card-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  padding: 1rem;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
+}
+
+.date-range-popover.open {
+  display: block;
+}
+
+.date-range-popover-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.6rem;
+}
+
+.date-range-nav-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  padding: 0.2rem;
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+
+.date-range-nav-btn:hover {
+  color: var(--accent-color);
+}
+
+.date-range-nav-btn svg {
+  width: 18px;
+  height: 18px;
+}
+
+.date-range-month-label {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  text-transform: capitalize;
+}
+
+.date-range-weekdays {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  text-align: center;
+  font-size: 0.7rem;
+  color: var(--text-secondary);
+  margin-bottom: 0.25rem;
+}
+
+.date-range-days {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 2px;
+}
+
+.date-range-day {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  aspect-ratio: 1;
+  border-radius: 50%;
+  font-size: 0.8rem;
+  color: var(--text-primary);
+  background: transparent;
+  cursor: pointer;
+  user-select: none;
+}
+
+.date-range-day:hover {
+  background: var(--accent-glow);
+}
+
+.date-range-day.is-other-month {
+  color: var(--text-secondary);
+  opacity: 0.4;
+  pointer-events: none;
+}
+
+.date-range-day.is-today {
+  border: 1px solid var(--accent-color);
+}
+
+.date-range-day.in-range {
+  background: var(--accent-glow);
+  border-radius: 0;
+}
+
+.date-range-day.is-start,
+.date-range-day.is-end {
+  background: var(--accent-color);
+  color: #fff;
+}
+
+.date-range-summary {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 0.75rem;
+  padding-top: 0.75rem;
+  border-top: 1px solid var(--border-color);
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+}
+
+.date-range-summary strong {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+.date-range-popover-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin-top: 0.85rem;
+}
+
 /* Loading Spinner */
 .loader {
   width: 48px;

--- a/src/styles/_legacy.scss
+++ b/src/styles/_legacy.scss
@@ -36,10 +36,7 @@ header {
 h1 {
     font-size: 2rem;
     font-weight: 700;
-    background: linear-gradient(90deg, var(--accent-color), color-mix(in srgb, var(--accent-color) 72%, white));
-    -webkit-background-clip: text;
-    background-clip: text;
-    -webkit-text-fill-color: transparent;
+    color: var(--accent-color);
 }
 
 .btn {
@@ -142,8 +139,6 @@ h1 {
     margin-bottom: 3rem;
     font-size: 2.5rem;
     color: white;
-    background: none;
-    -webkit-text-fill-color: initial;
 }
 
 .profiles-grid {

--- a/src/styles/_legacy.scss
+++ b/src/styles/_legacy.scss
@@ -821,6 +821,198 @@ input:focus, select:focus {
     box-shadow: 0 0 0 2px var(--accent-glow);
 }
 
+/* Validação inline de formulário (preferencias.md §12): borda vermelha + texto no
+   próprio campo, em vez de só um toast genérico depois de bater na API. */
+input.is-invalid, select.is-invalid, textarea.is-invalid {
+    border-color: var(--danger-color);
+}
+
+input.is-invalid:focus, select.is-invalid:focus, textarea.is-invalid:focus {
+    border-color: var(--danger-color);
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--danger-color) 35%, transparent);
+}
+
+.field-error {
+    display: none;
+    margin-top: 0.35rem;
+    font-size: 0.8rem;
+    color: var(--danger-color);
+}
+
+.field-error.visible {
+    display: block;
+}
+
+/* Componente de período (data início/fim) — issue pr-manager-cloud#18. Calendário único
+   em popover ancorado no campo, seguindo o mesmo padrão de diálogo customizado do resto
+   do projeto (markup estático + JS liga os elementos, ver src/dateRangePicker.js). */
+.date-range-field {
+    position: relative;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.date-range-field input {
+    flex: 1;
+    min-width: 0;
+}
+
+.date-range-arrow {
+    width: 16px;
+    height: 16px;
+    color: var(--text-secondary);
+    flex-shrink: 0;
+}
+
+.date-range-calendar-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: none;
+    border: none;
+    padding: 0.3rem;
+    color: var(--text-secondary);
+    cursor: pointer;
+    flex-shrink: 0;
+}
+
+.date-range-calendar-btn:hover {
+    color: var(--accent-color);
+}
+
+.date-range-calendar-btn svg {
+    width: 18px;
+    height: 18px;
+}
+
+.date-range-popover {
+    display: none;
+    position: absolute;
+    top: calc(100% + 0.5rem);
+    left: 0;
+    z-index: 20;
+    width: 280px;
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 10px;
+    padding: 1rem;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
+}
+
+.date-range-popover.open {
+    display: block;
+}
+
+.date-range-popover-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 0.6rem;
+}
+
+.date-range-nav-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: none;
+    border: none;
+    padding: 0.2rem;
+    color: var(--text-secondary);
+    cursor: pointer;
+}
+
+.date-range-nav-btn:hover {
+    color: var(--accent-color);
+}
+
+.date-range-nav-btn svg {
+    width: 18px;
+    height: 18px;
+}
+
+.date-range-month-label {
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: var(--text-primary);
+    text-transform: capitalize;
+}
+
+.date-range-weekdays {
+    display: grid;
+    grid-template-columns: repeat(7, 1fr);
+    text-align: center;
+    font-size: 0.7rem;
+    color: var(--text-secondary);
+    margin-bottom: 0.25rem;
+}
+
+.date-range-days {
+    display: grid;
+    grid-template-columns: repeat(7, 1fr);
+    gap: 2px;
+}
+
+.date-range-day {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    aspect-ratio: 1;
+    border-radius: 50%;
+    font-size: 0.8rem;
+    color: var(--text-primary);
+    background: transparent;
+    cursor: pointer;
+    user-select: none;
+}
+
+.date-range-day:hover {
+    background: var(--accent-glow);
+}
+
+.date-range-day.is-other-month {
+    color: var(--text-secondary);
+    opacity: 0.4;
+    pointer-events: none;
+}
+
+.date-range-day.is-today {
+    border: 1px solid var(--accent-color);
+}
+
+.date-range-day.in-range {
+    background: var(--accent-glow);
+    border-radius: 0;
+}
+
+.date-range-day.is-start,
+.date-range-day.is-end {
+    background: var(--accent-color);
+    color: #fff;
+}
+
+.date-range-summary {
+    display: flex;
+    justify-content: space-between;
+    margin-top: 0.75rem;
+    padding-top: 0.75rem;
+    border-top: 1px solid var(--border-color);
+    font-size: 0.8rem;
+    color: var(--text-secondary);
+}
+
+.date-range-summary strong {
+    color: var(--text-primary);
+    font-weight: 600;
+}
+
+.date-range-popover-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.5rem;
+    margin-top: 0.85rem;
+}
+
 /* Loading Spinner */
 .loader {
     width: 48px;


### PR DESCRIPTION
Fecha a task https://github.com/SamuelAraag/pr-manager/issues/50 e corrige, de carona, uma regressão encontrada ao validar a mudança.

## 1. Títulos com cor chapada (task #50)

A regra global `h1` pintava todos os títulos com `linear-gradient` + `background-clip: text` + `-webkit-text-fill-color: transparent`. Agora usa `color: var(--accent-color)` chapado — segue theme-aware nos temas claro e escuro.

Como o gradiente sai da regra base, dois pontos que existiam só para desfazê-lo ficaram obsoletos e foram removidos:

- `.profile-container h1`: `background: none` e `-webkit-text-fill-color: initial`;
- bloco de `#appTitle` em `src/script.js`, que aplicava cor sólida para admin e gradiente para os demais — os dois ramos agora produzem o mesmo resultado.

## 2. CSS perdido no build anterior (tela Nova Sprint)

O commit `decadb4` rodou `npm run build:styles` e o `style.css` regenerado apagou 192 linhas que existiam **só** no CSS compilado e nunca tinham sido portadas para o SCSS: `.field-error`, `input/select/textarea.is-invalid` e todo o componente `.date-range-*`.

Efeito no modal "Nova Sprint", único lugar que usa essas classes:

- o calendário de período ficava sempre aberto e sem estilo dentro do modal (`.date-range-popover` caía em `display: block` / `position: static`);
- as duas mensagens de erro apareciam permanentemente (`.field-error` sem `display: none`);
- "Data início" e "Data fim" empilhavam em vez de ficarem lado a lado (`.date-range-field` sem `display: flex`).

As regras voltaram para `src/styles/_legacy.scss`, na mesma posição em que estavam, para que o build volte a reproduzi-las. O bloco regenerado é idêntico ao que havia sido perdido.

`src/style.css` foi regenerado com `npm run build:styles` nas duas mudanças — a fonte de verdade é `src/styles/_legacy.scss`.

## Plano de teste

**Títulos:** login e dashboard (`index.html`), `apps.html`, `usuarios.html`, `tenants.html`, `ambientes.html`, `organizacoes.html` e `monitor-de-status.html` — título com cor chapada, sem degradê e sem texto invisível. Repetir nos temas claro e escuro e conferir logado como admin e como não-admin (deve ficar idêntico).

**Nova Sprint:** abrir o modal — nenhuma mensagem de erro visível, campos de data lado a lado, calendário fechado. Clicar no ícone de calendário abre o popover ancorado no campo. Salvar sem nome deve mostrar a borda vermelha e "Informe o nome da sprint." só nesse momento.
