### PR TITLE
fix: substitui confirmação nativa ao deslogar pelo modal padrão

### DIFF
--- a/index.html
+++ b/index.html
@@ -464,9 +464,12 @@
         </div>
     </div>
 
-    <!-- Confirmação contextual para arquivamento de PR (sem confirm() nativo). -->
+    <!-- Confirmação contextual reutilizável (sem confirm() nativo): arquivar PR, deslogar etc.
+         z-index acima das telas bloqueantes (profileScreen/tenantSelectScreen/noTenantScreen),
+         senão a confirmação de logout da tela "sem tenant" abriria atrás dela. -->
     <div id="confirmDialog" class="modal-overlay" role="dialog" aria-modal="true"
-        aria-labelledby="confirmDialogTitle" aria-describedby="confirmDialogMessage" aria-hidden="true">
+        aria-labelledby="confirmDialogTitle" aria-describedby="confirmDialogMessage" aria-hidden="true"
+        style="z-index: 2200;">
         <div class="modal-content" style="max-width: 420px;">
             <div class="modal-header">
                 <h2 id="confirmDialogTitle">Arquivar PR</h2>

--- a/src/script.js
+++ b/src/script.js
@@ -444,7 +444,13 @@ document.getElementById('tenantSwitchBtn')?.addEventListener('click', async () =
     }
 });
 
-document.getElementById('noTenantLogoutBtn')?.addEventListener('click', () => {
+document.getElementById('noTenantLogoutBtn')?.addEventListener('click', async () => {
+    const confirmado = await confirmarLogout();
+
+    if (!confirmado) {
+        return;
+    }
+
     document.getElementById('noTenantScreen').style.display = 'none';
     LocalStorage.clearSession();
     showProfileSelection();
@@ -573,11 +579,23 @@ if (loginForm) {
     });
 }
 
-function handleLogout() {
-    if (!confirm('Tem certeza que deseja deslogar?')) {
+// Confirmação de logout no modal padrão da página (#confirmDialog), compartilhada pelos dois
+// pontos de saída: o botão do header e o "Sair" da tela de "sem tenant".
+function confirmarLogout() {
+    return DOM.confirmDialog(
+        'Tem certeza que deseja deslogar?',
+        'Deslogar',
+        { confirmLabel: 'Deslogar', danger: true }
+    );
+}
+
+async function handleLogout() {
+    const confirmado = await confirmarLogout();
+
+    if (!confirmado) {
         return;
     }
-    
+
     LocalStorage.clearSession();
     showProfileSelection();
     


### PR DESCRIPTION
Fecha a task https://github.com/SamuelAraag/pr-manager/issues/38.

## O que muda

- `handleLogout()` deixa de usar `confirm()` nativo e passa a usar o `#confirmDialog` padrão da página, o mesmo já usado no arquivamento de PR.
- A confirmação foi extraída em `confirmarLogout()` e reaproveitada no botão "Sair" da tela de "sem tenant" (`#noTenantLogoutBtn`), que antes deslogava direto, sem nenhuma confirmação - decisão de escopo registrada em comentário na issue.
- `#confirmDialog` ganhou `z-index: 2200` inline: no valor herdado do `.modal-overlay` (1000) ele abriria atrás das telas bloqueantes (`profileScreen`, `tenantSelectScreen`, `noTenantScreen`, todas em 2000/2100), deixando a confirmação de logout da tela "sem tenant" invisível.

## Plano de teste

1. Logado no dashboard, clicar em deslogar - o modal padrão aparece com "Deslogar"/"Cancelar".
2. Cancelar (botão, clique fora e Esc) - permanece logado.
3. Confirmar - sessão limpa, tela de login e toast "Usuário deslogado!".
4. Com um usuário sem tenant vinculado, na tela "sem tenant", clicar em "Sair" - o modal aparece **por cima** da tela bloqueante; cancelar mantém a tela, confirmar volta para o login.
5. Arquivar um PR - confirmação continua funcionando normalmente (mesmo modal).
