### PR TITLE
Estabiliza sessão, CRUD de PR e formulários legados

### DIFF
--- a/apps.html
+++ b/apps.html
@@ -11,7 +11,7 @@
 </head>
 
 <body>
-    <div class="container">
+    <div class="container auth-guarded">
         <header class="module-page-header">
             <div class="logo-area">
                 <div>
@@ -53,10 +53,12 @@
                 <label class="module-field">
                     <span>Nome</span>
                     <input id="appFormName" type="text" required placeholder="Ex: YouTube">
+                    <span class="field-error">Informe o nome da aplicação.</span>
                 </label>
                 <label class="module-field">
                     <span>Repositório (URL)</span>
                     <input id="appFormRepo" type="url" placeholder="https://github.com/org/repo/">
+                    <span class="field-error">Informe uma URL válida para o repositório.</span>
                 </label>
                 <label class="module-field">
                     <span>Descrição</span>
@@ -64,7 +66,7 @@
                 </label>
                 <div class="module-form-actions">
                     <button class="btn btn-outline close-modal" type="button">Cancelar</button>
-                    <button class="btn btn-primary" type="submit">Salvar</button>
+                    <button id="appFormSubmit" class="btn btn-primary" type="submit">Salvar</button>
                 </div>
             </form>
         </div>

--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@
         </div>
     </div>
 
-    <div class="container">
+    <div class="container auth-guarded">
         <header>
             <div class="logo-area">
                 <div style="display: flex; align-items: center; gap: 1rem;">
@@ -383,14 +383,20 @@
                         </label>
                         <select id="project" required>
                         </select>
+                        <span class="field-error">Selecione uma aplicação.</span>
+                        <div id="projectEmptyState" class="form-empty-state" style="display: none;">
+                            Nenhuma aplicação está disponível neste tenant. Solicite acesso ou peça o cadastro ao administrador.
+                            <a id="projectEmptyAdminLink" href="apps.html?new=1" style="display: none;">Cadastrar aplicação</a>
+                        </div>
                         <div id="projectHelpTooltip" class="field-help-tooltip" style="display: none;">
                             Não encontrou a aplicação na lista? Ela precisa estar cadastrada no PR Manager primeiro.
-                            <a href="apps.html?new=1" target="_blank" rel="noopener">Cadastrar aplicação →</a>
+                            <a href="apps.html?new=1" target="_blank" rel="noopener" data-roles="Admin">Cadastrar aplicação →</a>
                         </div>
                     </div>
                     <div class="form-group">
                         <label>Desenvolvedor</label>
                         <input type="text" id="dev" list="devList" placeholder="Selecione ou digite..." required>
+                        <span class="field-error">Selecione o desenvolvedor.</span>
                         <datalist id="devList">
                             <option value="Rodrigo Barbosa">
                             <option value="Itallo Cerqueira">
@@ -404,18 +410,22 @@
                     <div class="form-group full-width">
                         <label>Resumo</label>
                         <input type="text" id="summary" placeholder="Ex: Correção do cálculo de imposto" required>
+                        <span class="field-error">Informe o resumo do PR.</span>
                     </div>
                     <div class="form-group">
                         <label>Link PR</label>
                         <input type="url" id="prLink" placeholder="https://bitbucket.org/...">
+                        <span class="field-error">Informe uma URL válida para o PR.</span>
                     </div>
                     <div class="form-group">
                         <label>Link Task (Jira)</label>
                         <input type="url" id="taskLink" placeholder="https://atlassian.net/...">
+                        <span class="field-error">Informe uma URL válida para a task.</span>
                     </div>
                     <div class="form-group" style="display: flex; flex-direction: column; gap: 0.5rem;">
                         <label>Post no Teams</label>
                         <input type="url" id="teamsLink" placeholder="Link da mensagem">
+                        <span class="field-error">Informe uma URL válida para o post no Teams.</span>
                     </div>
 
                     <div style="display: flex; align-items: center; gap: 0.6rem; margin-top: 0.3rem;">
@@ -458,7 +468,7 @@
                 </div>
                 <div style="margin-top: 2rem; display: flex; justify-content: flex-end; gap: 1rem;">
                     <button type="button" class="btn btn-outline close-modal">Cancelar</button>
-                    <button type="submit" class="btn btn-primary">Salvar</button>
+                    <button id="prSubmitBtn" type="submit" class="btn btn-primary">Salvar</button>
                 </div>
             </form>
         </div>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,9 @@
 {
   "name": "pr-manager-frontend",
   "private": true,
+  "type": "module",
   "scripts": {
+    "test": "node --test",
     "build:styles": "sass --load-path=node_modules --silence-deprecation=import --quiet-deps src/styles/styles.scss src/style.css --style=expanded --no-source-map",
     "watch:styles": "sass --load-path=node_modules --silence-deprecation=import --quiet-deps --watch src/styles/styles.scss:src/style.css --style=expanded --no-source-map",
     "build:styles:prod": "sass --load-path=node_modules --silence-deprecation=import --quiet-deps src/styles/styles.scss src/style.min.css --style=compressed --no-source-map",

--- a/src/apiService.js
+++ b/src/apiService.js
@@ -22,6 +22,13 @@ function getBackendHeaders() {
   return headers;
 }
 
+export async function parseResponseBody(response) {
+  if (response.status === 204) return null;
+  const text = await response.text();
+  if (!text.trim()) return null;
+  return JSON.parse(text);
+}
+
 // Helper genérico para os endpoints novos do Épico 9 (Tenants, Convites, Memberships,
 // Notificações) — mesmo padrão de appsRequest/environmentsRequest, sem repetir por recurso.
 async function apiRequest(path, options = {}) {
@@ -30,10 +37,10 @@ async function apiRequest(path, options = {}) {
     ...options,
   });
   if (!response.ok) {
-    const body = await response.json().catch(() => ({}));
-    throw new Error(body.error || `Erro na API: ${response.statusText}`);
+    const body = await parseResponseBody(response).catch(() => ({}));
+    throw new Error(body?.error || `Erro na API: ${response.statusText}`);
   }
-  return response.status === 204 ? null : await response.json();
+  return parseResponseBody(response);
 }
 
 // ── Identidade fresca (Épico 9 Fase 3) ──────────────────────────────────────
@@ -150,14 +157,11 @@ async function createPR(prData) {
     });
 
     if (!response.ok) {
-      const errorBody = await response.json().catch(() => ({}));
-      throw new Error(
-        `Erro ao criar PR: ${errorBody.error || errorBody.message || response.statusText}`,
-      );
+      const errorBody = await parseResponseBody(response).catch(() => ({}));
+      throw new Error(errorBody?.error || errorBody?.message || `Erro ao criar PR: ${response.statusText}`);
     }
 
-    const data = await response.json();
-    return data;
+    return await parseResponseBody(response);
   } catch (error) {
     console.error("Falha ao criar PR:", error);
     throw error;
@@ -175,14 +179,11 @@ async function updatePR(prId, prData) {
     });
 
     if (!response.ok) {
-      const errorBody = await response.json();
-      throw new Error(
-        `Erro ao atualizar PR: ${errorBody.message || response.statusText}`,
-      );
+      const errorBody = await parseResponseBody(response).catch(() => ({}));
+      throw new Error(errorBody?.error || errorBody?.message || `Erro ao atualizar PR: ${response.statusText}`);
     }
 
-    const data = await response.json();
-    return data;
+    return await parseResponseBody(response);
   } catch (error) {
     console.error("Falha ao atualizar PR:", error);
     throw error;
@@ -558,10 +559,10 @@ async function appsRequest(path, options = {}) {
     ...options,
   });
   if (!response.ok) {
-    const body = await response.json().catch(() => ({}));
-    throw new Error(body.error || `Erro na API de apps: ${response.statusText}`);
+    const body = await parseResponseBody(response).catch(() => ({}));
+    throw new Error(body?.error || `Erro na API de apps: ${response.statusText}`);
   }
-  return response.status === 204 ? null : await response.json();
+  return parseResponseBody(response);
 }
 
 const fetchApps = () => appsRequest("");
@@ -628,10 +629,10 @@ async function createUser(userData) {
     body: JSON.stringify(userData),
   });
   if (!response.ok) {
-    const body = await response.json().catch(() => ({}));
-    throw new Error(body.error || `Erro ao criar usuário: ${response.statusText}`);
+    const body = await parseResponseBody(response).catch(() => ({}));
+    throw new Error(body?.error || `Erro ao criar usuário: ${response.statusText}`);
   }
-  return await response.json();
+  return parseResponseBody(response);
 }
 
 async function updateUser(id, userData) {
@@ -641,10 +642,10 @@ async function updateUser(id, userData) {
     body: JSON.stringify(userData),
   });
   if (!response.ok) {
-    const body = await response.json().catch(() => ({}));
-    throw new Error(body.error || `Erro ao atualizar usuário: ${response.statusText}`);
+    const body = await parseResponseBody(response).catch(() => ({}));
+    throw new Error(body?.error || `Erro ao atualizar usuário: ${response.statusText}`);
   }
-  return await response.json();
+  return parseResponseBody(response);
 }
 
 async function deactivateUser(id) {
@@ -653,10 +654,10 @@ async function deactivateUser(id) {
     headers: getBackendHeaders(),
   });
   if (!response.ok) {
-    const body = await response.json().catch(() => ({}));
-    throw new Error(body.error || `Erro ao desativar usuário: ${response.statusText}`);
+    const body = await parseResponseBody(response).catch(() => ({}));
+    throw new Error(body?.error || `Erro ao desativar usuário: ${response.statusText}`);
   }
-  return await response.json();
+  return parseResponseBody(response);
 }
 
 async function archivePR(prId) {

--- a/src/appsHome.js
+++ b/src/appsHome.js
@@ -6,27 +6,27 @@ import * as AuthService from './authService.js';
 import * as LocalStorage from './localStorageService.js';
 import * as DOM from './domService.js';
 import { initializeTheme } from './themeService.js';
+import * as Form from './formService.js';
 
+AuthService.markAuthenticationPending();
 initializeTheme('themeToggleBtn');
 DOM.enableEscapeToCloseModals();
 
-// Rota exige sessão; papel Admin libera as ações de gestão
 LocalStorage.init?.();
-if (!LocalStorage.getItem('token')) {
-    window.location.href = 'index.html';
-}
 // isAdmin decide quem edita/desativa apps e gerencia membros — precisa bater exatamente com
 // a policy RequireTenantAdmin do backend (PlatformAdmin OU TenantAdmin do tenant atual), não
 // com o papel legado global (User.Role) que AuthService.isAdmin() lê do JWT. Um usuário pode
 // ser "Admin" nesse campo legado e ainda assim ser só Developer/Member no tenant atual — o
 // backend já rejeita (403) esse caso, mas o botão de editar não pode nem aparecer pra ele.
-// Setado por init() abaixo, depois de refreshMe() popular o papel no tenant atual.
+// Setado por init() abaixo, depois de restoreSession() popular o papel no tenant atual.
 let isAdmin = false;
 
 const appsGrid = document.getElementById('appsGrid');
 const appsCount = document.getElementById('appsCount');
 const appFormModal = document.getElementById('appFormModal');
 const membersModal = document.getElementById('membersModal');
+const appForm = document.getElementById('appForm');
+Form.prepareForm(appForm);
 
 let appsState = [];
 let membersAppId = null;
@@ -106,6 +106,7 @@ async function renderApps() {
 // ── Formulário de app (Admin) ────────────────────────────────────────────────
 
 function openAppForm(app = null) {
+    Form.resetFormState(appForm);
     document.getElementById('appFormTitle').textContent = app ? `Editar: ${app.name}` : 'Novo App';
     document.getElementById('appFormId').value = app ? app.id : '';
     document.getElementById('appFormName').value = app ? app.name : '';
@@ -118,9 +119,17 @@ function openAppForm(app = null) {
 document.getElementById('appForm')?.addEventListener('submit', async (e) => {
     e.preventDefault();
     const id = document.getElementById('appFormId').value;
+    const nameField = document.getElementById('appFormName');
+    const repositoryField = document.getElementById('appFormRepo');
+    if (!Form.validateFields([
+        { field: nameField, validate: Form.isRequired, message: 'Informe o nome da aplicação.' },
+        { field: repositoryField, validate: Form.isOptionalUrl, message: 'Informe uma URL válida para o repositório.' }
+    ])) return;
+    if (!Form.beginFormSubmission(appForm)) return;
+
     const payload = {
-        name: document.getElementById('appFormName').value.trim(),
-        repositoryUrl: document.getElementById('appFormRepo').value.trim(),
+        name: nameField.value.trim(),
+        repositoryUrl: repositoryField.value.trim(),
         description: document.getElementById('appFormDescription').value.trim() || null
     };
 
@@ -129,8 +138,11 @@ document.getElementById('appForm')?.addEventListener('submit', async (e) => {
         else await API.createApp(payload);
         appFormModal.style.display = 'none';
         await renderApps();
+        DOM.showToast('Aplicação salva com sucesso.');
     } catch (error) {
-        await DOM.alertDialog(traduzErro(error));
+        DOM.showToast(traduzErro(error), 'error');
+    } finally {
+        Form.endFormSubmission(appForm);
     }
 });
 
@@ -148,11 +160,8 @@ async function openMembers(appId) {
         // Candidatos são os membros ativos do tenant atual (TenantMembership), não
         // API.fetchUsers() — essa lista é filtrada pela coluna legada User.TenantId e não
         // enxerga usuários vinculados a este tenant só via convite/TenantMembership.
-        // AuthService.getMe() não serve aqui: essa rota nunca chama refreshMe(), então o
-        // cache em memória do módulo authService fica nulo neste carregamento de página.
-        // currentTenantId persiste em localStorage desde o último refreshMe() (login/troca
-        // de tenant), então é a fonte confiável fora das páginas que chamam refreshMe().
-        const tenantId = LocalStorage.getItem('currentTenantId');
+        // A sessão já foi revalidada no boot; usa o tenant confirmado pelo /Users/me.
+        const tenantId = AuthService.getMe()?.currentTenantId;
         const tenantMembers = tenantId ? await API.fetchTenantMemberships(tenantId) : [];
         select.innerHTML = '<option value="">Selecione um usuário</option>';
         tenantMembers
@@ -243,14 +252,21 @@ function traduzErro(error) {
 document.querySelectorAll('.close-btn, .close-modal').forEach(btn =>
     btn.addEventListener('click', () => {
         appFormModal.style.display = 'none';
+        Form.resetFormState(appForm);
         membersModal.style.display = 'none';
     }));
 
 async function init() {
+    const session = await AuthService.restoreSession();
+    if (session.state !== 'ready') {
+        window.location.href = 'index.html';
+        return;
+    }
+
     // Identidade fresca (fonte: /Users/me, não o JWT) pra resolver o papel no tenant atual —
     // sem isso getRoleInCurrentTenant()/isPlatformAdmin() ficam nulos nesta página.
-    await AuthService.refreshMe();
     isAdmin = AuthService.isAdminGlobal();
+    AuthService.applyRoleBasedVisibility();
 
     if (isAdmin) {
         const newBtn = document.getElementById('appNewBtn');

--- a/src/authService.js
+++ b/src/authService.js
@@ -3,7 +3,7 @@
  * Centralized service for JWT token handling and role-based access control
  */
 
-import { getItem, setItem } from './localStorageService.js';
+import { clearSession, getItem, removeItem, setItem } from './localStorageService.js';
 import { ROLES, PERMISSIONS } from './constants/roles.js';
 import * as API from './apiService.js';
 
@@ -103,6 +103,14 @@ export async function refreshMe() {
     try {
         const me = await API.fetchMe();
         meCache = me;
+        if (me?.name) setItem('appUser', me.name);
+        if (me?.id) setItem('appUserId', me.id);
+
+        const tenantIds = (me?.tenants || []).map(tenant => tenant.tenantId);
+        const storedTenantId = getItem('currentTenantId');
+        if (storedTenantId && !tenantIds.includes(storedTenantId)) {
+            removeItem('currentTenantId');
+        }
         if (me?.currentTenantId) {
             setItem('currentTenantId', me.currentTenantId);
         }
@@ -112,6 +120,47 @@ export async function refreshMe() {
         meCache = null;
         return null;
     }
+}
+
+/**
+ * Restaura uma sessão persistida e garante que o tenant salvo ainda pertence ao usuário.
+ * Páginas que não possuem seletor devem redirecionar para o Dashboard quando o retorno for
+ * "tenant-selection-required" ou "no-tenant".
+ */
+export async function restoreSession() {
+    if (!getItem('token')) return { state: 'unauthenticated', me: null };
+
+    let me = await refreshMe();
+    if (!me) {
+        clearSession();
+        return { state: 'unauthenticated', me: null };
+    }
+
+    const tenants = me.tenants || [];
+    if (tenants.length === 0) {
+        removeItem('currentTenantId');
+        return { state: 'no-tenant', me };
+    }
+
+    if (!me.currentTenantId && tenants.length === 1) {
+        setItem('currentTenantId', tenants[0].tenantId);
+        me = await refreshMe();
+        if (!me) {
+            clearSession();
+            return { state: 'unauthenticated', me: null };
+        }
+    }
+
+    if (!me.currentTenantId) {
+        return { state: 'tenant-selection-required', me };
+    }
+
+    return { state: 'ready', me };
+}
+
+export async function activateTenant(tenantId) {
+    setItem('currentTenantId', tenantId);
+    return refreshMe();
 }
 
 /** @returns {object|null} último resultado cacheado de refreshMe() */
@@ -294,6 +343,12 @@ export function applyRoleBasedVisibility() {
             element.style.display = 'none';
         }
     });
+
+    document.documentElement.classList.add('auth-ready');
+}
+
+export function markAuthenticationPending() {
+    document.documentElement.classList.remove('auth-ready');
 }
 
 // Export all functions
@@ -316,5 +371,8 @@ export default {
     refreshMe,
     getMe,
     getRoleInCurrentTenant,
-    getMyTenants
+    getMyTenants,
+    restoreSession,
+    activateTenant,
+    markAuthenticationPending
 };

--- a/src/formService.js
+++ b/src/formService.js
@@ -1,0 +1,96 @@
+function findErrorElement(field) {
+    if (!field) return null;
+    const container = field.closest?.('.form-group, .module-field');
+    return container?.querySelector?.('.field-error') || null;
+}
+
+export function setFieldError(field, message) {
+    if (!field) return;
+    const errorElement = findErrorElement(field);
+    field.classList.add('is-invalid');
+    field.setAttribute('aria-invalid', 'true');
+    if (errorElement) {
+        errorElement.textContent = message;
+        errorElement.classList.add('visible');
+    }
+}
+
+export function clearFieldError(field) {
+    if (!field) return;
+    const errorElement = findErrorElement(field);
+    field.classList.remove('is-invalid');
+    field.removeAttribute('aria-invalid');
+    if (errorElement) errorElement.classList.remove('visible');
+}
+
+export function clearFormErrors(form) {
+    form?.querySelectorAll('input, select, textarea').forEach(clearFieldError);
+}
+
+export function prepareForm(form) {
+    if (!form || form.dataset.validationReady === 'true') return;
+    form.dataset.validationReady = 'true';
+    form.noValidate = true;
+    form.addEventListener('input', event => clearFieldError(event.target));
+    form.addEventListener('change', event => clearFieldError(event.target));
+}
+
+export function validateFields(rules) {
+    let firstInvalidField = null;
+
+    rules.forEach(({ field, validate, message }) => {
+        if (!field) return;
+        clearFieldError(field);
+        if (!validate(field.value, field)) {
+            setFieldError(field, message);
+            firstInvalidField ||= field;
+        }
+    });
+
+    firstInvalidField?.focus();
+    return firstInvalidField === null;
+}
+
+export function isRequired(value) {
+    return String(value ?? '').trim().length > 0;
+}
+
+export function isValidEmail(value) {
+    const normalized = String(value ?? '').trim();
+    return normalized.length > 0 && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(normalized);
+}
+
+export function isOptionalUrl(value) {
+    const normalized = String(value ?? '').trim();
+    if (!normalized) return true;
+    try {
+        const url = new URL(normalized);
+        return url.protocol === 'http:' || url.protocol === 'https:';
+    } catch {
+        return false;
+    }
+}
+
+export function beginFormSubmission(form) {
+    if (!form || form.dataset.submitting === 'true') return false;
+    form.dataset.submitting = 'true';
+    form.setAttribute('aria-busy', 'true');
+    form.querySelectorAll('[type="submit"]').forEach(button => {
+        button.disabled = true;
+    });
+    return true;
+}
+
+export function endFormSubmission(form) {
+    if (!form) return;
+    delete form.dataset.submitting;
+    form.removeAttribute('aria-busy');
+    form.querySelectorAll('[type="submit"]').forEach(button => {
+        button.disabled = button.dataset.permanentDisabled === 'true';
+    });
+}
+
+export function resetFormState(form) {
+    clearFormErrors(form);
+    endFormSubmission(form);
+}

--- a/src/formService.js
+++ b/src/formService.js
@@ -94,3 +94,12 @@ export function resetFormState(form) {
     clearFormErrors(form);
     endFormSubmission(form);
 }
+
+export function bindDismissButton(button, onDismiss) {
+    if (!button || typeof onDismiss !== 'function') return;
+    button.addEventListener('click', event => {
+        event.preventDefault();
+        event.stopPropagation();
+        onDismiss();
+    });
+}

--- a/src/script.js
+++ b/src/script.js
@@ -10,6 +10,7 @@ import { connectSignalR } from './notificationService.js';
 import { isLocalDev, DEMO_MODE, DEMO_USERS, getDemoProject } from './constants/apiConstants.js';
 import { initializeTheme } from './themeService.js';
 import { initDateRangePicker } from './dateRangePicker.js';
+import * as Form from './formService.js';
 
 let currentData = { prs: [] };
 let availableUsers = [];
@@ -22,6 +23,7 @@ const appFilter = new URLSearchParams(window.location.search).get('app');
 // id do app filtrado (resolvido quando a lista de apps carrega) — chave real do filtro de PRs/lotes
 let currentAppId = null;
 
+AuthService.markAuthenticationPending();
 initializeTheme('themeToggleBtn');
 
 // Épico 5.3: o <select id="project"> não tem mais lista fixa no HTML — vem inteira da
@@ -51,6 +53,8 @@ async function loadProjectOptions() {
             }
         }
 
+        updateProjectEmptyState(apps);
+
         if (appFilter) {
             const app = apps.find(a => a.name === appFilter);
             AuthService.setCurrentAppRole(app?.myRole ?? null);
@@ -67,6 +71,20 @@ async function loadProjectOptions() {
         }
     } catch (error) {
         console.error('Erro ao carregar lista de apps:', error);
+    }
+}
+
+function updateProjectEmptyState(apps) {
+    const hasApps = Array.isArray(apps) && apps.length > 0;
+    const emptyState = document.getElementById('projectEmptyState');
+    const adminLink = document.getElementById('projectEmptyAdminLink');
+    const submitButton = document.getElementById('prSubmitBtn');
+
+    if (emptyState) emptyState.style.display = hasApps ? 'none' : 'block';
+    if (adminLink) adminLink.style.display = !hasApps && AuthService.isAdminGlobal() ? 'inline' : 'none';
+    if (submitButton) {
+        submitButton.dataset.permanentDisabled = hasApps ? 'false' : 'true';
+        submitButton.disabled = !hasApps;
     }
 }
 
@@ -119,26 +137,35 @@ function setPrCreationRequiredState(isCreate) {
     });
 }
 
-function validatePrCreationForm() {
-    const requiredFields = [
-        { id: 'project', label: 'Projeto' },
-        { id: 'dev', label: 'Desenvolvedor' },
-        { id: 'summary', label: 'Resumo' },
-        { id: 'prLink', label: 'Link PR' },
-        { id: 'taskLink', label: 'Link Task (Jira)' },
-        { id: 'teamsLink', label: 'Post no Teams' },
+function validatePrForm(isCreate) {
+    const project = document.getElementById('project');
+    const dev = document.getElementById('dev');
+    const summary = document.getElementById('summary');
+    const prLink = document.getElementById('prLink');
+    const taskLink = document.getElementById('taskLink');
+    const teamsLink = document.getElementById('teamsLink');
+    const rules = [
+        { field: project, validate: Form.isRequired, message: 'Selecione uma aplicação.' },
+        { field: dev, validate: Form.isRequired, message: 'Selecione o desenvolvedor.' },
+        { field: summary, validate: Form.isRequired, message: 'Informe o resumo do PR.' },
+        { field: prLink, validate: value => (!isCreate || Form.isRequired(value)) && Form.isOptionalUrl(value), message: 'Informe uma URL válida para o PR.' },
+        { field: taskLink, validate: value => (!isCreate || Form.isRequired(value)) && Form.isOptionalUrl(value), message: 'Informe uma URL válida para a task.' },
+        { field: teamsLink, validate: value => (!isCreate || Form.isRequired(value)) && Form.isOptionalUrl(value), message: 'Informe uma URL válida para o post no Teams.' },
     ];
 
-    for (const fieldInfo of requiredFields) {
-        const value = document.getElementById(fieldInfo.id)?.value.trim();
-        if (!value) {
-            DOM.showToast(`${fieldInfo.label} é obrigatório.`, 'warning');
-            document.getElementById(fieldInfo.id)?.focus();
-            return false;
-        }
-    }
+    document.querySelectorAll('.related-task-group').forEach(group => {
+        const urlField = group.querySelector('.related-task-input-url');
+        const summaryField = group.querySelector('.related-task-input-summary');
+        rules.push({
+            field: urlField,
+            validate: value => Form.isRequired(value)
+                ? Form.isOptionalUrl(value)
+                : !Form.isRequired(summaryField?.value),
+            message: 'Informe uma URL válida para a task relacionada.'
+        });
+    });
 
-    return true;
+    return Form.validateFields(rules);
 }
 
 function getPrErrorMessage(errorMessage) {
@@ -191,6 +218,7 @@ const currentUserDisplayRight = document.getElementById('currentUserDisplayRight
 const godModeContainer = document.getElementById('godModeContainer');
 const godModeInput = document.getElementById('godModeInput');
 let pendingVersionRequestContext = null;
+Form.prepareForm(prForm);
 
 if (currentUserDisplay) currentUserDisplay.addEventListener('click', showProfileSelection);
 if (currentUserDisplayRight) currentUserDisplayRight.addEventListener('click', showProfileSelection);
@@ -340,31 +368,30 @@ if (godModeInput) {
 // currentTenantId em localStorage aponta pra um tenant válido antes de carregar dados —
 // toda chamada à API depois disso já sai com o header X-Tenant-Id certo.
 async function ensureTenantContext() {
-    const me = await AuthService.refreshMe();
-    if (!me) {
-        // token inválido/expirado: volta pro login em vez de travar a tela
-        LocalStorage.clearSession();
+    const session = await AuthService.restoreSession();
+    if (session.state === 'unauthenticated') {
         showProfileSelection();
         return false;
     }
 
+    let me = session.me;
     const tenants = me.tenants || [];
-    if (tenants.length === 0) {
+    if (session.state === 'no-tenant') {
         document.getElementById('noTenantScreen').style.display = 'flex';
         return false;
     }
 
-    const storedId = LocalStorage.getItem('currentTenantId');
-    const storedIsValid = storedId && tenants.some(t => t.tenantId === storedId);
-
-    if (tenants.length === 1) {
-        LocalStorage.setItem('currentTenantId', tenants[0].tenantId);
-    } else if (!storedIsValid) {
+    if (session.state === 'tenant-selection-required') {
         const chosenId = await showTenantSelector(tenants);
-        LocalStorage.setItem('currentTenantId', chosenId);
-        await AuthService.refreshMe(); // refaz com o header certo pra pegar o papel no tenant escolhido
+        me = await AuthService.activateTenant(chosenId);
+        if (!me) {
+            LocalStorage.clearSession();
+            showProfileSelection();
+            return false;
+        }
     }
 
+    document.getElementById('noTenantScreen').style.display = 'none';
     updateTenantSwitcher();
     return true;
 }
@@ -429,10 +456,9 @@ document.getElementById('tenantSwitchBtn')?.addEventListener('click', async () =
     const chosenId = await showTenantSelector(me.tenants, LocalStorage.getItem('currentTenantId'));
     if (chosenId === LocalStorage.getItem('currentTenantId')) return;
 
-    LocalStorage.setItem('currentTenantId', chosenId);
     DOM.showLoading(true);
     try {
-        await AuthService.refreshMe();
+        await AuthService.activateTenant(chosenId);
         updateTenantSwitcher();
         AuthService.applyRoleBasedVisibility();
         await loadProjectOptions();
@@ -458,6 +484,7 @@ document.getElementById('noTenantLogoutBtn')?.addEventListener('click', async ()
 
 function closeAllModals() {
     prModal.style.display = 'none';
+    Form.resetFormState(prForm);
     if (setupModal) setupModal.style.display = 'none';
     if (shortcutsModal) shortcutsModal.style.display = 'none';
     if (requestVersionModal) requestVersionModal.style.display = 'none';
@@ -483,14 +510,13 @@ async function init() {
     applyDevMode();
     populateDevList();
 
-    const appUser = LocalStorage.getItem('appUser');
-    if (!appUser) {
+    if (!LocalStorage.getItem('token')) {
         showProfileSelection();
     } else {
-        updateUserDisplay(appUser);
-
         const tenantOk = await ensureTenantContext();
         if (!tenantOk) return;
+        const appUser = LocalStorage.getItem('appUser');
+        updateUserDisplay(appUser);
         AuthService.applyRoleBasedVisibility();
 
         await loadProjectOptions();
@@ -608,6 +634,7 @@ function showProfileSelection() {
     const errorEl = document.getElementById('loginError');
     if (passwordInput) passwordInput.value = '';
     if (errorEl) errorEl.style.display = 'none';
+    AuthService.markAuthenticationPending();
 
     profileScreen.style.display = 'flex';
     document.body.classList.add('no-scroll');
@@ -675,10 +702,8 @@ async function loadUsers() {
     try {
         const users = await API.fetchUsers();
 
-        if (Array.isArray(users) && users.length > 0) {
-            availableUsers = users;
-            populateDevList();
-        }
+        availableUsers = Array.isArray(users) ? users : [];
+        populateDevList();
     } catch (error) {
         console.error('Erro ao carregar usuários:', error);
     }
@@ -846,6 +871,7 @@ function refreshApprovedPrs(animate = false) {
 }
 
 function openEditModal(pr) {
+    Form.resetFormState(prForm);
     document.getElementById('modalTitle').textContent = 'Editar Pull Request';
     setPrCreationRequiredState(false);
     document.getElementById('prId').value = pr.id;
@@ -917,6 +943,7 @@ async function openAddModal() {
     document.getElementById('modalTitle').textContent = 'Novo Pull Request';
     setPrCreationRequiredState(true);
     prForm.reset();
+    Form.resetFormState(prForm);
     document.getElementById('prId').value = '';
     
     updateSummaryLabel();
@@ -1064,8 +1091,9 @@ function addRelatedTaskInput(url = '', summary = '') {
     }
     
     const div = document.createElement('div');
-    div.className = 'related-task-group';
+    div.className = 'related-task-group form-group';
     div.style.display = 'flex';
+    div.style.flexWrap = 'wrap';
     div.style.gap = '10px';
     div.style.alignItems = 'center';
     
@@ -1110,6 +1138,9 @@ function addRelatedTaskInput(url = '', summary = '') {
     div.appendChild(summaryInput);
     div.appendChild(urlInput);
     div.appendChild(removeBtn);
+    const errorElement = document.createElement('span');
+    errorElement.className = 'field-error';
+    div.appendChild(errorElement);
     container.appendChild(div);
     
     if(window.lucide) {
@@ -1444,15 +1475,17 @@ prForm.addEventListener('submit', async (e) => {
     const prIdInput = document.getElementById('prId').value;
     const devName = devInputForForm.value;
 
-    if (!prIdInput && !validatePrCreationForm()) {
+    if (!validatePrForm(!prIdInput)) {
         return;
     }
 
     if (!availableUsers.find(u => u.name === devName)) {
-        DOM.showToast('Por favor, selecione um desenvolvedor válido da lista.', 'warning');
+        Form.setFieldError(devInputForForm, 'Selecione um desenvolvedor válido da lista.');
         devInputForForm.focus();
         return;
     }
+
+    if (!Form.beginFormSubmission(prForm)) return;
 
     try {
         DOM.showLoading(true);
@@ -1460,7 +1493,7 @@ prForm.addEventListener('submit', async (e) => {
         const devId = getUserIdByName(devName);
         
         if (!devId) {
-            DOM.showToast('Atenção: Desenvolvedor não encontrado', 'warning');
+            Form.setFieldError(devInputForForm, 'Desenvolvedor não encontrado no tenant atual.');
             return;
         }
         
@@ -1482,35 +1515,32 @@ prForm.addEventListener('submit', async (e) => {
                 .join(';')
         };
 
-        let savedPR;
-        
+        const successMessage = prIdInput
+            ? 'PR atualizado com sucesso!'
+            : 'PR criado com sucesso!';
+
         if (prIdInput) {
-            savedPR = await API.updatePR(prIdInput, prData);
-            // DOM.showToast('PR atualizado com sucesso!');
-            
-            // Local update
-            const index = currentData.prs.findIndex(p => p.id == prIdInput);
-            if (index !== -1 && savedPR) {
-                currentData.prs[index] = savedPR;
-            }
+            await API.updatePR(prIdInput, prData);
         } else {
-            savedPR = await API.createPR(prData);
-            DOM.showToast('PR criado com sucesso!');
-            
-            if (savedPR) {
-                currentData.prs.push(savedPR);
-            }
+            await API.createPR(prData);
         }
-        
-        refreshOpenPrs();
-        
+
         prModal.style.display = 'none';
         prForm.reset();
+        DOM.showToast(successMessage);
+
+        try {
+            await loadPrTablesData(true);
+        } catch (refreshError) {
+            console.error('PR salvo, mas o Dashboard não pôde ser atualizado:', refreshError);
+            DOM.showToast('PR salvo. Atualize a página para recarregar o Dashboard.', 'warning');
+        }
     } catch (error) {
         console.error('Erro detalhado ao salvar:', error);
         DOM.showToast('Erro ao salvar: ' + getPrErrorMessage(error.message), 'error');
     } finally {
         DOM.showLoading(false);
+        Form.endFormSubmission(prForm);
     }
 });
 

--- a/src/script.js
+++ b/src/script.js
@@ -11,9 +11,11 @@ import { isLocalDev, DEMO_MODE, DEMO_USERS, getDemoProject } from './constants/a
 import { initializeTheme } from './themeService.js';
 import { initDateRangePicker } from './dateRangePicker.js';
 import * as Form from './formService.js';
+import { createTenantOperationGuard } from './tenantOperationGuard.js';
 
 let currentData = { prs: [] };
 let availableUsers = [];
+const tenantOperations = createTenantOperationGuard();
 
 // Filtro por app (Épico 3): apps.html manda para index.html?app=<nome>. O nome na URL só
 // resolve o app (abaixo, currentAppId); a listagem de PRs/lotes filtra por AppId (FK), não
@@ -29,12 +31,13 @@ initializeTheme('themeToggleBtn');
 // Épico 5.3: o <select id="project"> não tem mais lista fixa no HTML — vem inteira da
 // API (mesmos apps que a Home de Apps do Épico 3 já lista). Também resolve o papel do
 // usuário NO APP filtrado (Épico 4.3, reaproveitando o "myRole" que GET /Apps já calcula).
-async function loadProjectOptions() {
+async function loadProjectOptions(expectedRevision = tenantOperations.snapshot()) {
     const projectSelect = document.getElementById('project');
     const previousValue = projectSelect?.value;
 
     try {
         const apps = await API.fetchApps();
+        if (!tenantOperations.isCurrent(expectedRevision)) return false;
         if (!Array.isArray(apps)) return;
 
         if (projectSelect) {
@@ -69,8 +72,11 @@ async function loadProjectOptions() {
                 projectSelect.title = 'Projeto herdado do app selecionado';
             }
         }
+        return true;
     } catch (error) {
+        if (!tenantOperations.isCurrent(expectedRevision)) return false;
         console.error('Erro ao carregar lista de apps:', error);
+        return false;
     }
 }
 
@@ -451,21 +457,35 @@ function updateTenantSwitcher() {
 
 document.getElementById('tenantSwitchBtn')?.addEventListener('click', async () => {
     const me = AuthService.getMe();
-    if (!me || !(me.tenants || []).length) return;
+    if (!me || !(me.tenants || []).length || tenantOperations.isTransitioning()) return;
 
-    const chosenId = await showTenantSelector(me.tenants, LocalStorage.getItem('currentTenantId'));
-    if (chosenId === LocalStorage.getItem('currentTenantId')) return;
-
-    DOM.showLoading(true);
+    const transitionRevision = tenantOperations.beginTransition();
+    const addPrButton = document.getElementById('addPrBtn');
+    if (addPrButton) addPrButton.disabled = true;
+    closeAllModals();
     try {
-        await AuthService.activateTenant(chosenId);
+        const currentTenantId = LocalStorage.getItem('currentTenantId');
+        const chosenId = await showTenantSelector(me.tenants, currentTenantId);
+        if (chosenId === currentTenantId) return;
+
+        DOM.showLoading(true);
+        const activatedMe = await AuthService.activateTenant(chosenId);
+        if (!tenantOperations.isCurrent(transitionRevision)) return;
+        if (!activatedMe) throw new Error('Não foi possível ativar o tenant selecionado.');
         updateTenantSwitcher();
         AuthService.applyRoleBasedVisibility();
-        await loadProjectOptions();
+        await loadProjectOptions(transitionRevision);
+        if (!tenantOperations.isCurrent(transitionRevision)) return;
         applyDemoProjectsToSelect();
-        await loadData(true);
+        await loadData(true, transitionRevision);
+        if (!tenantOperations.isCurrent(transitionRevision)) return;
         DOM.showToast('Tenant alterado.');
+    } catch (error) {
+        console.error('Erro ao trocar tenant:', error);
+        DOM.showToast('Não foi possível trocar o tenant.', 'error');
     } finally {
+        tenantOperations.endTransition(transitionRevision);
+        if (addPrButton) addPrButton.disabled = false;
         DOM.showLoading(false);
     }
 });
@@ -694,18 +714,22 @@ function getVersionAssignableUsers() {
     return availableUsers.filter(user => (user.role || '').toLowerCase() === 'dev');
 }
 
-async function loadUsers() {
+async function loadUsers(expectedRevision = tenantOperations.snapshot()) {
     // Issue #34: sem token não há lista de usuários — o endpoint anônimo de perfis foi
     // removido (vazava usuários de todos os tenants) e a tela de login já é e-mail + senha.
     if (!LocalStorage.getItem('token')) return;
 
     try {
         const users = await API.fetchUsers();
+        if (!tenantOperations.isCurrent(expectedRevision)) return false;
 
         availableUsers = Array.isArray(users) ? users : [];
         populateDevList();
+        return true;
     } catch (error) {
+        if (!tenantOperations.isCurrent(expectedRevision)) return false;
         console.error('Erro ao carregar usuários:', error);
+        return false;
     }
 }
 
@@ -788,24 +812,27 @@ async function confirmRequestVersionSelection() {
     }
 }
 
-async function loadPrTablesData(animate = false) {
+async function loadPrTablesData(animate = false, expectedRevision = tenantOperations.snapshot()) {
     const prResult = await API.fetchPRs();
+    if (!tenantOperations.isCurrent(expectedRevision)) return false;
     if (!prResult || !Array.isArray(prResult.prs)) {
         throw new Error('Falha ao carregar PRs');
     }
-    currentData.prs = appFilter
-        ? prResult.prs.filter(p => p.appId === currentAppId)
-        : prResult.prs;
-    refreshOpenPrs(animate);
-
     const batches = await API.fetchBatches();
+    if (!tenantOperations.isCurrent(expectedRevision)) return false;
     if (!Array.isArray(batches)) {
         throw new Error('Falha ao carregar lotes');
     }
+
+    currentData.prs = appFilter
+        ? prResult.prs.filter(p => p.appId === currentAppId)
+        : prResult.prs;
     currentData.batches = appFilter
         ? batches.filter(b => b.appId === currentAppId)
         : batches;
+    refreshOpenPrs(animate);
     refreshApprovedPrs(animate);
+    return true;
 }
 
 function refreshTestingAndHistory(animate = false) {
@@ -819,7 +846,7 @@ function refreshTestingAndHistory(animate = false) {
     if (AuthService && AuthService.applyRoleBasedVisibility) AuthService.applyRoleBasedVisibility();
 }
 
-async function loadData(skipLoading = false) {
+async function loadData(skipLoading = false, expectedRevision = tenantOperations.snapshot()) {
     const token = LocalStorage.getItem('token');
     const appUser = LocalStorage.getItem('appUser');
     
@@ -828,22 +855,26 @@ async function loadData(skipLoading = false) {
     }
     
     try {
-        await loadUsers();
+        await loadUsers(expectedRevision);
+        if (!tenantOperations.isCurrent(expectedRevision)) return;
 
         // Sequential boot: open PRs first, then approved PRs
-        await loadPrTablesData(false);
+        await loadPrTablesData(false, expectedRevision);
+        if (!tenantOperations.isCurrent(expectedRevision)) return;
 
         const sprints = await API.fetchSprints();
+        if (!tenantOperations.isCurrent(expectedRevision)) return;
         if (!Array.isArray(sprints)) {
             throw new Error('Falha ao carregar sprints');
         }
         currentData.sprints = sprints;
         refreshTestingAndHistory(false);
     } catch (error) {
+        if (!tenantOperations.isCurrent(expectedRevision)) return;
         console.error('Erro ao carregar dados:', error);
         DOM.showToast('Erro ao carregar dados da API', 'error');
     } finally {
-        if (!skipLoading) {
+        if (!skipLoading && tenantOperations.isCurrent(expectedRevision)) {
             DOM.showLoading(false);
         }
     }
@@ -939,7 +970,13 @@ function openEditModal(pr) {
     prModal.style.display = 'flex';
 }
 
-async function openAddModal() {
+function openAddModal() {
+    if (tenantOperations.isTransitioning()) {
+        DOM.showToast('Aguarde a troca de tenant terminar.', 'info');
+        return;
+    }
+
+    const openingRevision = tenantOperations.snapshot();
     document.getElementById('modalTitle').textContent = 'Novo Pull Request';
     setPrCreationRequiredState(true);
     prForm.reset();
@@ -950,15 +987,7 @@ async function openAddModal() {
     
     document.getElementById('relatedTasksContainer').innerHTML = '';
 
-    let currentMe = null;
-    try {
-        currentMe = await AuthService.refreshMe();
-    } catch (error) {
-        console.error('Erro ao buscar identidade atual para o modal de PR:', error);
-    }
-
-    await loadUsers();
-
+    const currentMe = AuthService.getMe();
     const appUser = currentMe?.name || LocalStorage.getItem('appUser');
     if (appUser) {
         document.getElementById('dev').value = appUser;
@@ -984,7 +1013,8 @@ async function openAddModal() {
 
     const addRelatedBtn = document.getElementById('addRelatedTaskBtn');
     if (addRelatedBtn) addRelatedBtn.disabled = false;
-    
+
+    if (!tenantOperations.isCurrent(openingRevision) || tenantOperations.isTransitioning()) return;
     prModal.style.display = 'flex';
 }
 

--- a/src/style.css
+++ b/src/style.css
@@ -3093,6 +3093,28 @@ input.is-invalid:focus, select.is-invalid:focus, textarea.is-invalid:focus {
   display: block;
 }
 
+html:not(.auth-ready) .auth-guarded,
+html:not(.auth-ready) [data-roles] {
+  visibility: hidden !important;
+}
+
+.form-empty-state {
+  margin-top: 0.5rem;
+  padding: 0.75rem;
+  border: 1px solid var(--warning-color);
+  border-radius: 6px;
+  color: var(--text-secondary);
+  background: color-mix(in srgb, var(--warning-color) 10%, transparent);
+  font-size: 0.85rem;
+}
+
+.form-empty-state a {
+  display: inline-block;
+  margin-left: 0.35rem;
+  color: var(--accent-color);
+  font-weight: 600;
+}
+
 /* Componente de período (data início/fim) — issue pr-manager-cloud#18. Calendário único
    em popover ancorado no campo, seguindo o mesmo padrão de diálogo customizado do resto
    do projeto (markup estático + JS liga os elementos, ver src/dateRangePicker.js). */

--- a/src/styles/_legacy.scss
+++ b/src/styles/_legacy.scss
@@ -843,6 +843,28 @@ input.is-invalid:focus, select.is-invalid:focus, textarea.is-invalid:focus {
     display: block;
 }
 
+html:not(.auth-ready) .auth-guarded,
+html:not(.auth-ready) [data-roles] {
+    visibility: hidden !important;
+}
+
+.form-empty-state {
+    margin-top: 0.5rem;
+    padding: 0.75rem;
+    border: 1px solid var(--warning-color);
+    border-radius: 6px;
+    color: var(--text-secondary);
+    background: color-mix(in srgb, var(--warning-color) 10%, transparent);
+    font-size: 0.85rem;
+}
+
+.form-empty-state a {
+    display: inline-block;
+    margin-left: 0.35rem;
+    color: var(--accent-color);
+    font-weight: 600;
+}
+
 /* Componente de período (data início/fim) — issue pr-manager-cloud#18. Calendário único
    em popover ancorado no campo, seguindo o mesmo padrão de diálogo customizado do resto
    do projeto (markup estático + JS liga os elementos, ver src/dateRangePicker.js). */

--- a/src/tenantOperationGuard.js
+++ b/src/tenantOperationGuard.js
@@ -1,0 +1,24 @@
+export function createTenantOperationGuard() {
+    let revision = 0;
+    let transitioning = false;
+
+    return {
+        snapshot() {
+            return revision;
+        },
+        beginTransition() {
+            transitioning = true;
+            revision += 1;
+            return revision;
+        },
+        endTransition(expectedRevision) {
+            if (revision === expectedRevision) transitioning = false;
+        },
+        isCurrent(expectedRevision) {
+            return revision === expectedRevision;
+        },
+        isTransitioning() {
+            return transitioning;
+        }
+    };
+}

--- a/src/tenantsAdmin.js
+++ b/src/tenantsAdmin.js
@@ -406,7 +406,8 @@ tenantForm?.addEventListener('submit', async (e) => {
 });
 
 document.getElementById('tenantNewBtn')?.addEventListener('click', () => openTenantForm());
-tenantModal?.querySelectorAll('.close-btn, .close-modal').forEach(btn => btn.addEventListener('click', closeTenantForm));
+Form.bindDismissButton(document.getElementById('tenantFormCancel'), closeTenantForm);
+Form.bindDismissButton(tenantModal?.querySelector('.close-btn'), closeTenantForm);
 
 // ── Convites pendentes (§8.3/§8.4 do plano — só PlatformAdmin aprova/rejeita/remove) ──────
 

--- a/src/tenantsAdmin.js
+++ b/src/tenantsAdmin.js
@@ -6,7 +6,9 @@ import * as AuthService from './authService.js';
 import * as LocalStorage from './localStorageService.js';
 import * as DOM from './domService.js';
 import { initializeTheme } from './themeService.js';
+import * as Form from './formService.js';
 
+AuthService.markAuthenticationPending();
 initializeTheme('themeToggleBtn');
 DOM.enableEscapeToCloseModals();
 
@@ -23,6 +25,8 @@ let adminUsuarioEncontrado = null;
 let membrosSelecionados = new Set();
 let editingTenantId = null;
 let editMembersState = [];
+Form.prepareForm(tenantForm);
+Form.prepareForm(approveForm);
 
 function traduzErro(error) {
     const friendly = {
@@ -316,6 +320,7 @@ function renderEditMembersAddList() {
 document.getElementById('tenantEditMembersFilter')?.addEventListener('input', renderEditMembersAddList);
 
 function openTenantForm(tenant = null) {
+    Form.resetFormState(tenantForm);
     document.getElementById('tenantFormTitle').textContent = tenant ? `Editar: ${tenant.name}` : 'Novo tenant';
     document.getElementById('tenantFormId').value = tenant ? tenant.id : '';
     document.getElementById('tenantFormName').value = tenant ? tenant.name : '';
@@ -352,6 +357,7 @@ function openTenantForm(tenant = null) {
 
 function closeTenantForm() {
     tenantModal.style.display = 'none';
+    Form.resetFormState(tenantForm);
 }
 
 document.getElementById('tenantFormAdminEmail')?.addEventListener('input', atualizarCamposConformeEmail);
@@ -359,21 +365,33 @@ document.getElementById('tenantFormAdminEmail')?.addEventListener('input', atual
 tenantForm?.addEventListener('submit', async (e) => {
     e.preventDefault();
     const id = document.getElementById('tenantFormId').value;
+    const nameField = document.getElementById('tenantFormName');
+    const adminEmailField = document.getElementById('tenantFormAdminEmail');
+    const adminNameField = document.getElementById('tenantFormAdminName');
+    const adminPasswordField = document.getElementById('tenantFormAdminPassword');
+    const adminEmailFilled = !id && Form.isRequired(adminEmailField.value);
+    if (!Form.validateFields([
+        { field: nameField, validate: Form.isRequired, message: 'Informe o nome do tenant.' },
+        { field: adminEmailField, validate: value => !!id || !Form.isRequired(value) || Form.isValidEmail(value), message: 'Informe um email válido.' },
+        { field: adminNameField, validate: value => !adminEmailFilled || !!adminUsuarioEncontrado || Form.isRequired(value), message: 'Informe o nome do administrador.' },
+        { field: adminPasswordField, validate: value => !adminEmailFilled || !!adminUsuarioEncontrado || Form.isRequired(value), message: 'Informe a senha inicial do administrador.' }
+    ])) return;
+    if (!Form.beginFormSubmission(tenantForm)) return;
 
     try {
         if (id) {
             await API.updateTenant(id, {
-                name: document.getElementById('tenantFormName').value.trim(),
+                name: nameField.value.trim(),
                 status: document.getElementById('tenantFormStatus').value,
             });
         } else {
             await API.createTenant({
-                name: document.getElementById('tenantFormName').value.trim(),
-                adminEmail: document.getElementById('tenantFormAdminEmail').value.trim(),
+                name: nameField.value.trim(),
+                adminEmail: adminEmailField.value.trim(),
                 // §2.3 do plano: e-mail já existente vincula sem precisar disso — o backend
                 // ignora nome/senha quando encontra o usuário pelo e-mail.
-                adminName: adminUsuarioEncontrado ? '' : document.getElementById('tenantFormAdminName').value.trim(),
-                adminPassword: adminUsuarioEncontrado ? '' : document.getElementById('tenantFormAdminPassword').value,
+                adminName: adminUsuarioEncontrado ? '' : adminNameField.value.trim(),
+                adminPassword: adminUsuarioEncontrado ? '' : adminPasswordField.value,
                 memberUserIds: [...membrosSelecionados],
             });
         }
@@ -382,6 +400,8 @@ tenantForm?.addEventListener('submit', async (e) => {
         DOM.showToast('Tenant salvo com sucesso.');
     } catch (error) {
         DOM.showToast(traduzErro(error), 'error');
+    } finally {
+        Form.endFormSubmission(tenantForm);
     }
 });
 
@@ -453,6 +473,7 @@ async function renderInvitationsTable() {
 }
 
 function openApproveForm(invitationId) {
+    Form.resetFormState(approveForm);
     document.getElementById('approveFormId').value = invitationId;
     document.getElementById('approveFormPassword').value = '';
     approveModal.style.display = 'flex';
@@ -460,12 +481,14 @@ function openApproveForm(invitationId) {
 
 function closeApproveForm() {
     approveModal.style.display = 'none';
+    Form.resetFormState(approveForm);
 }
 
 approveForm?.addEventListener('submit', async (e) => {
     e.preventDefault();
     const id = document.getElementById('approveFormId').value;
     const password = document.getElementById('approveFormPassword').value;
+    if (!Form.beginFormSubmission(approveForm)) return;
 
     try {
         await API.approveInvitation(id, password ? { initialPassword: password } : {});
@@ -474,6 +497,8 @@ approveForm?.addEventListener('submit', async (e) => {
         DOM.showToast('Convite aprovado.');
     } catch (error) {
         DOM.showToast(traduzErro(error), 'error');
+    } finally {
+        Form.endFormSubmission(approveForm);
     }
 });
 
@@ -481,18 +506,21 @@ approveModal?.querySelectorAll('.close-btn, .close-modal').forEach(btn => btn.ad
 
 async function boot() {
     LocalStorage.init?.();
-    if (!LocalStorage.getItem('token')) {
+    const session = await AuthService.restoreSession();
+    if (session.state !== 'ready') {
         window.location.href = 'index.html';
         return;
     }
 
     // Guarda de acesso: rota é só de PlatformAdmin. O backend (policy RequirePlatformAdmin)
     // é a fonte de verdade — isto só evita renderizar a tela pra quem não deveria vê-la.
-    const me = await AuthService.refreshMe();
+    const me = session.me;
     if (!me || !me.isPlatformAdmin) {
         window.location.href = 'index.html';
         return;
     }
+
+    AuthService.applyRoleBasedVisibility();
 
     await renderTenantsTable();
     await renderInvitationsTable();

--- a/src/usersAdmin.js
+++ b/src/usersAdmin.js
@@ -5,7 +5,9 @@ import * as AuthService from './authService.js';
 import * as LocalStorage from './localStorageService.js';
 import * as DOM from './domService.js';
 import { initializeTheme } from './themeService.js';
+import * as Form from './formService.js';
 
+AuthService.markAuthenticationPending();
 initializeTheme('themeToggleBtn');
 DOM.enableEscapeToCloseModals();
 
@@ -17,6 +19,8 @@ const inviteForm = document.getElementById('inviteForm');
 
 let usersState = [];
 let membershipsState = [];
+Form.prepareForm(userForm);
+Form.prepareForm(inviteForm);
 
 async function renderUsersTable() {
     const tbody = document.getElementById('usersTableBody');
@@ -66,6 +70,7 @@ async function renderUsersTable() {
 }
 
 function openUserForm(user = null) {
+    Form.resetFormState(userForm);
     document.getElementById('userFormTitle').textContent = user ? `Editar: ${user.name}` : 'Novo usuário';
     document.getElementById('userFormId').value = user ? user.id : '';
     document.getElementById('userFormName').value = user ? user.name : '';
@@ -85,6 +90,7 @@ function openUserForm(user = null) {
 
 function closeUserForm() {
     userModal.style.display = 'none';
+    Form.resetFormState(userForm);
 }
 
 function traduzErro(error) {
@@ -114,9 +120,19 @@ document.addEventListener('keydown', (e) => {
 userForm?.addEventListener('submit', async (e) => {
     e.preventDefault();
     const id = document.getElementById('userFormId').value;
+    const nameField = document.getElementById('userFormName');
+    const emailField = document.getElementById('userFormEmail');
+    const passwordField = document.getElementById('userFormPassword');
+    if (!Form.validateFields([
+        { field: nameField, validate: Form.isRequired, message: 'Informe o nome do usuário.' },
+        { field: emailField, validate: Form.isValidEmail, message: 'Informe um email válido.' },
+        { field: passwordField, validate: value => !!id || Form.isRequired(value), message: 'Informe a senha inicial.' }
+    ])) return;
+    if (!Form.beginFormSubmission(userForm)) return;
+
     const payload = {
-        name: document.getElementById('userFormName').value.trim(),
-        email: document.getElementById('userFormEmail').value.trim(),
+        name: nameField.value.trim(),
+        email: emailField.value.trim(),
         role: document.getElementById('userFormRole').value,
         // Issue #41: isAdmin não é mais enviado — o backend deriva de Papel = Admin.
         avatarUrl: document.getElementById('userFormAvatar').value.trim() || null
@@ -126,14 +142,13 @@ userForm?.addEventListener('submit', async (e) => {
     if (AuthService.isPlatformAdmin()) {
         payload.isPlatformAdmin = document.getElementById('userFormIsPlatformAdmin').checked;
     }
-    const password = document.getElementById('userFormPassword').value;
+    const password = passwordField.value;
     if (password) payload.password = password;
 
     try {
         if (id) {
             await API.updateUser(id, payload);
         } else {
-            if (!password) { DOM.showToast('Senha é obrigatória para criar usuário.', 'error'); return; }
             await API.createUser(payload);
         }
         closeUserForm();
@@ -141,6 +156,8 @@ userForm?.addEventListener('submit', async (e) => {
         DOM.showToast('Usuário salvo com sucesso.');
     } catch (error) {
         DOM.showToast(traduzErro(error), 'error');
+    } finally {
+        Form.endFormSubmission(userForm);
     }
 });
 
@@ -218,6 +235,7 @@ async function renderMembershipsTable() {
 }
 
 function openInviteForm() {
+    Form.resetFormState(inviteForm);
     document.getElementById('inviteFormEmail').value = '';
     document.getElementById('inviteFormRole').value = 'Member';
     inviteModal.style.display = 'flex';
@@ -226,6 +244,7 @@ function openInviteForm() {
 
 function closeInviteForm() {
     inviteModal.style.display = 'none';
+    Form.resetFormState(inviteForm);
 }
 
 document.getElementById('membershipInviteBtn')?.addEventListener('click', openInviteForm);
@@ -235,22 +254,30 @@ inviteForm?.addEventListener('submit', async (e) => {
     e.preventDefault();
     const tenantId = AuthService.getMe()?.currentTenantId;
     if (!tenantId) return;
+    const emailField = document.getElementById('inviteFormEmail');
+    if (!Form.validateFields([
+        { field: emailField, validate: Form.isValidEmail, message: 'Informe um email válido.' }
+    ])) return;
+    if (!Form.beginFormSubmission(inviteForm)) return;
 
     try {
         await API.createTenantInvitation(tenantId, {
-            email: document.getElementById('inviteFormEmail').value.trim(),
+            email: emailField.value.trim(),
             requestedTenantRole: document.getElementById('inviteFormRole').value
         });
         closeInviteForm();
         DOM.showToast('Convite enviado — aguardando aprovação do administrador da plataforma.');
     } catch (error) {
         DOM.showToast(traduzErro(error), 'error');
+    } finally {
+        Form.endFormSubmission(inviteForm);
     }
 });
 
 async function boot() {
     LocalStorage.init?.();
-    if (!LocalStorage.getItem('token')) {
+    const session = await AuthService.restoreSession();
+    if (session.state !== 'ready') {
         window.location.href = 'index.html';
         return;
     }
@@ -258,11 +285,13 @@ async function boot() {
     // Guarda de acesso: rota é de administrador do tenant. PlatformAdmin/TenantAdmin não são
     // mais claim do JWT (Épico 9) — precisa da checagem fresca via /Users/me. O backend
     // (policy RequireTenantAdmin) é a fonte de verdade; isto só evita renderizar a tela.
-    const me = await AuthService.refreshMe();
+    const me = session.me;
     if (!me || !AuthService.isAdminGlobal()) {
         window.location.href = 'index.html';
         return;
     }
+
+    AuthService.applyRoleBasedVisibility();
 
     await renderUsersTable();
     await renderMembershipsTable();

--- a/tenants.html
+++ b/tenants.html
@@ -171,7 +171,7 @@
                 </div>
 
                 <div class="module-form-actions">
-                    <button class="btn btn-outline close-modal" type="button">Cancelar</button>
+                    <button id="tenantFormCancel" class="btn btn-outline" type="button">Cancelar</button>
                     <button id="tenantFormSubmit" class="btn btn-primary" type="submit">Salvar</button>
                 </div>
             </form>

--- a/tenants.html
+++ b/tenants.html
@@ -11,7 +11,7 @@
 </head>
 
 <body>
-    <div class="container">
+    <div class="container auth-guarded">
         <header class="module-page-header">
             <div class="logo-area">
                 <div>
@@ -95,6 +95,7 @@
                 <label class="module-field" style="grid-column: 1 / -1;">
                     <span>Nome do tenant</span>
                     <input id="tenantFormName" type="text" required placeholder="Nome da organização">
+                    <span class="field-error">Informe o nome do tenant.</span>
                 </label>
 
                 <div id="tenantFormAdminFields" style="grid-column: 1 / -1; display: contents;">
@@ -106,6 +107,7 @@
                     <label class="module-field" style="grid-column: 1 / -1;">
                         <span>Email</span>
                         <input id="tenantFormAdminEmail" type="email" placeholder="admin@empresa.com (opcional)">
+                        <span class="field-error">Informe um email válido.</span>
                     </label>
 
                     <div id="tenantFormAdminFoundNote" style="grid-column: 1 / -1; display: none; padding: 0.6rem 0.85rem; border-radius: 8px; background: color-mix(in srgb, var(--success-color) 15%, transparent); border: 1px solid var(--success-color); font-size: 0.85rem;"></div>
@@ -113,11 +115,13 @@
                     <label class="module-field" id="tenantFormAdminNameField" style="grid-column: 1 / -1;">
                         <span>Nome completo</span>
                         <input id="tenantFormAdminName" type="text" placeholder="Nome completo">
+                        <span class="field-error">Informe o nome do administrador.</span>
                     </label>
 
                     <label class="module-field" id="tenantFormAdminPasswordField" style="grid-column: 1 / -1;">
                         <span>Senha inicial</span>
                         <input id="tenantFormAdminPassword" type="password" autocomplete="new-password">
+                        <span class="field-error">Informe a senha inicial do administrador.</span>
                     </label>
 
                     <div style="grid-column: 1 / -1; border-top: 1px solid var(--border-color); padding-top: 1rem; margin-top: 0.25rem;">
@@ -168,7 +172,7 @@
 
                 <div class="module-form-actions">
                     <button class="btn btn-outline close-modal" type="button">Cancelar</button>
-                    <button class="btn btn-primary" type="submit">Salvar</button>
+                    <button id="tenantFormSubmit" class="btn btn-primary" type="submit">Salvar</button>
                 </div>
             </form>
         </div>
@@ -192,7 +196,7 @@
                 </label>
                 <div class="module-form-actions">
                     <button class="btn btn-outline close-modal" type="button">Cancelar</button>
-                    <button class="btn btn-primary" type="submit">Aprovar</button>
+                    <button id="approveFormSubmit" class="btn btn-primary" type="submit">Aprovar</button>
                 </div>
             </form>
         </div>

--- a/test/apiService.test.js
+++ b/test/apiService.test.js
@@ -1,0 +1,46 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createPR, parseResponseBody, updatePR } from '../src/apiService.js';
+
+globalThis.localStorage = {
+    getItem: () => null
+};
+
+test('parseResponseBody retorna null para HTTP 204', async () => {
+    const response = new Response(null, { status: 204 });
+
+    assert.equal(await parseResponseBody(response), null);
+});
+
+test('parseResponseBody retorna null para resposta 200 vazia', async () => {
+    const response = new Response('', { status: 200 });
+
+    assert.equal(await parseResponseBody(response), null);
+});
+
+test('parseResponseBody preserva resposta JSON', async () => {
+    const response = new Response(JSON.stringify({ id: 35, name: 'PR' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+    });
+
+    assert.deepEqual(await parseResponseBody(response), { id: 35, name: 'PR' });
+});
+
+test('createPR aceita resposta 204 sem tentar interpretar JSON', async () => {
+    globalThis.fetch = async (_url, options) => {
+        assert.equal(options.method, 'POST');
+        return new Response(null, { status: 204 });
+    };
+
+    assert.equal(await createPR({ summary: 'Novo PR' }), null);
+});
+
+test('updatePR aceita resposta 200 vazia e deixa a recarga para a tela', async () => {
+    globalThis.fetch = async (_url, options) => {
+        assert.equal(options.method, 'PUT');
+        return new Response('', { status: 200 });
+    };
+
+    assert.equal(await updatePR(35, { summary: 'PR atualizado' }), null);
+});

--- a/test/authService.test.js
+++ b/test/authService.test.js
@@ -1,0 +1,55 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+class MemoryStorage {
+    #values = new Map();
+
+    getItem(key) { return this.#values.get(key) ?? null; }
+    setItem(key, value) { this.#values.set(key, String(value)); }
+    removeItem(key) { this.#values.delete(key); }
+    clear() { this.#values.clear(); }
+}
+
+globalThis.localStorage = new MemoryStorage();
+const LocalStorage = await import('../src/localStorageService.js');
+const AuthService = await import('../src/authService.js');
+
+test.beforeEach(() => {
+    localStorage.clear();
+    LocalStorage.setItem('token', 'token-de-teste');
+});
+
+test('restoreSession substitui tenant inválido quando existe apenas um vínculo', async () => {
+    const tenantId = '00000000-0000-0000-0000-000000000035';
+    LocalStorage.setItem('currentTenantId', 'tenant-removido');
+    const responses = [
+        { id: 7, name: 'Dev', currentTenantId: null, tenants: [{ tenantId, tenantName: 'Tenant', role: 'Member' }] },
+        { id: 7, name: 'Dev', currentTenantId: tenantId, tenants: [{ tenantId, tenantName: 'Tenant', role: 'Member' }] }
+    ];
+    globalThis.fetch = async () => new Response(JSON.stringify(responses.shift()), { status: 200 });
+
+    const session = await AuthService.restoreSession();
+
+    assert.equal(session.state, 'ready');
+    assert.equal(LocalStorage.getItem('currentTenantId'), tenantId);
+    assert.equal(LocalStorage.getItem('appUser'), 'Dev');
+    assert.equal(LocalStorage.getItem('appUserId'), 7);
+});
+
+test('restoreSession solicita seleção quando o tenant salvo não pertence mais ao usuário', async () => {
+    LocalStorage.setItem('currentTenantId', 'tenant-removido');
+    globalThis.fetch = async () => new Response(JSON.stringify({
+        id: 8,
+        name: 'QA',
+        currentTenantId: null,
+        tenants: [
+            { tenantId: 'tenant-a', tenantName: 'A', role: 'Member' },
+            { tenantId: 'tenant-b', tenantName: 'B', role: 'Member' }
+        ]
+    }), { status: 200 });
+
+    const session = await AuthService.restoreSession();
+
+    assert.equal(session.state, 'tenant-selection-required');
+    assert.equal(LocalStorage.getItem('currentTenantId'), null);
+});

--- a/test/formService.test.js
+++ b/test/formService.test.js
@@ -2,6 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import {
     beginFormSubmission,
+    bindDismissButton,
     endFormSubmission,
     isOptionalUrl,
     isRequired,
@@ -83,4 +84,23 @@ test('beginFormSubmission impede segundo envio e restaura o botão ao finalizar'
     assert.equal(beginFormSubmission(form), true);
     endFormSubmission(form);
     assert.equal(button.disabled, true);
+});
+
+test('bindDismissButton cancela o evento e executa o fechamento', () => {
+    let listener;
+    let dismissed = false;
+    const button = { addEventListener: (_event, callback) => { listener = callback; } };
+    const event = {
+        defaultPrevented: false,
+        propagationStopped: false,
+        preventDefault() { this.defaultPrevented = true; },
+        stopPropagation() { this.propagationStopped = true; }
+    };
+
+    bindDismissButton(button, () => { dismissed = true; });
+    listener(event);
+
+    assert.equal(event.defaultPrevented, true);
+    assert.equal(event.propagationStopped, true);
+    assert.equal(dismissed, true);
 });

--- a/test/formService.test.js
+++ b/test/formService.test.js
@@ -1,0 +1,86 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+    beginFormSubmission,
+    endFormSubmission,
+    isOptionalUrl,
+    isRequired,
+    isValidEmail,
+    validateFields
+} from '../src/formService.js';
+
+function createField(value = '') {
+    const classes = new Set();
+    const errorClasses = new Set();
+    const errorElement = {
+        textContent: '',
+        classList: {
+            add: value => errorClasses.add(value),
+            remove: value => errorClasses.delete(value)
+        }
+    };
+    return {
+        value,
+        focused: false,
+        classList: {
+            add: value => classes.add(value),
+            remove: value => classes.delete(value),
+            contains: value => classes.has(value)
+        },
+        setAttribute() {},
+        removeAttribute() {},
+        closest: () => ({ querySelector: () => errorElement }),
+        focus() { this.focused = true; },
+        errorElement,
+        errorClasses
+    };
+}
+
+test('validadores cobrem campos obrigatórios, email e URL', () => {
+    assert.equal(isRequired('  valor  '), true);
+    assert.equal(isRequired('   '), false);
+    assert.equal(isValidEmail('dev@tenant.com'), true);
+    assert.equal(isValidEmail('email-invalido'), false);
+    assert.equal(isOptionalUrl(''), true);
+    assert.equal(isOptionalUrl('https://jira.local/TASK-35'), true);
+    assert.equal(isOptionalUrl('javascript:alert(1)'), false);
+});
+
+test('validateFields marca o campo inválido com mensagem inline', () => {
+    const field = createField('');
+
+    const valid = validateFields([
+        { field, validate: isRequired, message: 'Campo obrigatório.' }
+    ]);
+
+    assert.equal(valid, false);
+    assert.equal(field.classList.contains('is-invalid'), true);
+    assert.equal(field.errorElement.textContent, 'Campo obrigatório.');
+    assert.equal(field.errorClasses.has('visible'), true);
+    assert.equal(field.focused, true);
+});
+
+test('beginFormSubmission impede segundo envio e restaura o botão ao finalizar', () => {
+    const button = { disabled: false, dataset: {} };
+    const attributes = new Map();
+    const form = {
+        dataset: {},
+        setAttribute: (key, value) => attributes.set(key, value),
+        removeAttribute: key => attributes.delete(key),
+        querySelectorAll: () => [button]
+    };
+
+    assert.equal(beginFormSubmission(form), true);
+    assert.equal(beginFormSubmission(form), false);
+    assert.equal(button.disabled, true);
+
+    endFormSubmission(form);
+
+    assert.equal(button.disabled, false);
+    assert.equal(attributes.has('aria-busy'), false);
+
+    button.dataset.permanentDisabled = 'true';
+    assert.equal(beginFormSubmission(form), true);
+    endFormSubmission(form);
+    assert.equal(button.disabled, true);
+});

--- a/test/tenantOperationGuard.test.js
+++ b/test/tenantOperationGuard.test.js
@@ -1,0 +1,26 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createTenantOperationGuard } from '../src/tenantOperationGuard.js';
+
+test('troca de tenant invalida operações iniciadas no tenant anterior', () => {
+    const guard = createTenantOperationGuard();
+    const previousRevision = guard.snapshot();
+
+    const transitionRevision = guard.beginTransition();
+
+    assert.equal(guard.isCurrent(previousRevision), false);
+    assert.equal(guard.isCurrent(transitionRevision), true);
+    assert.equal(guard.isTransitioning(), true);
+});
+
+test('uma transição antiga não encerra a troca mais recente', () => {
+    const guard = createTenantOperationGuard();
+    const firstRevision = guard.beginTransition();
+    const secondRevision = guard.beginTransition();
+
+    guard.endTransition(firstRevision);
+    assert.equal(guard.isTransitioning(), true);
+
+    guard.endTransition(secondRevision);
+    assert.equal(guard.isTransitioning(), false);
+});

--- a/usuarios.html
+++ b/usuarios.html
@@ -11,7 +11,7 @@
 </head>
 
 <body>
-    <div class="container">
+    <div class="container auth-guarded">
         <header class="module-page-header">
             <div class="logo-area">
                 <div>
@@ -101,16 +101,19 @@
                 <label class="module-field">
                     <span>Nome</span>
                     <input id="userFormName" type="text" required placeholder="Nome completo">
+                    <span class="field-error">Informe o nome do usuário.</span>
                 </label>
 
                 <label class="module-field">
                     <span>Email</span>
                     <input id="userFormEmail" type="email" required placeholder="pessoa@empresa.com">
+                    <span class="field-error">Informe um email válido.</span>
                 </label>
 
                 <label class="module-field">
                     <span>Senha <small id="userFormPasswordHint">(obrigatória)</small></span>
                     <input id="userFormPassword" type="password" autocomplete="new-password">
+                    <span class="field-error">Informe a senha inicial.</span>
                 </label>
 
                 <label class="module-field">
@@ -150,7 +153,7 @@
 
                 <div class="module-form-actions">
                     <button class="btn btn-outline close-modal" type="button">Cancelar</button>
-                    <button class="btn btn-primary" type="submit">Salvar</button>
+                    <button id="userFormSubmit" class="btn btn-primary" type="submit">Salvar</button>
                 </div>
             </form>
         </div>
@@ -168,6 +171,7 @@
                 <label class="module-field">
                     <span>Email</span>
                     <input id="inviteFormEmail" type="email" required placeholder="pessoa@empresa.com">
+                    <span class="field-error">Informe um email válido.</span>
                 </label>
 
                 <label class="module-field">
@@ -180,7 +184,7 @@
 
                 <div class="module-form-actions">
                     <button class="btn btn-outline close-modal" type="button">Cancelar</button>
-                    <button class="btn btn-primary" type="submit">Enviar convite</button>
+                    <button id="inviteFormSubmit" class="btn btn-primary" type="submit">Enviar convite</button>
                 </div>
             </form>
         </div>


### PR DESCRIPTION
## Resumo

- restaura e revalida usuário/tenant ao atualizar ou navegar entre Dashboard e Apps, sem exibir ações administrativas antes da autorização
- aceita criação/edição de PR com resposta vazia ou 204 e recarrega o Dashboard a partir do backend
- padroniza validação inline, cancelamento, feedback e bloqueio de duplo envio nos formulários de Tenant, Usuário, App, PR e task relacionada
- orienta o usuário quando o tenant não possui aplicações e restringe o atalho de cadastro a administradores

## Testes

- `npm test` — 10 testes passando
- `npm run build:styles`
- checagem de sintaxe dos módulos JavaScript
- validação local no navegador de login, refresh, navegação, tenant sem apps, validações e criação de PR com HTTP 204

Issue: https://github.com/SamuelAraag/pr-manager/issues/35

Backend relacionado: https://github.com/SamuelAraag/pr-manager/pull/55