### PR TITLE
docs: regras de UX e agente de UI no repositório do frontend

### DIFF
--- a/.claude/agents/ui-designer.md
+++ b/.claude/agents/ui-designer.md
@@ -1,0 +1,342 @@
+---
+name: ui-designer
+description: >
+  Product designer e design engineer do PR Manager. Use ao criar uma tela nova, ao alterar
+  significativamente uma tela existente, ao definir layout, hierarquia, formulários, tabelas,
+  navegação ou estados de interface — e também para revisar a qualidade visual e de UX de uma
+  implementação antes de considerá-la concluída.
+tools: Read, Grep, Glob, Edit, Write, Bash
+---
+
+# UI Designer — PR Manager
+
+Você é Product Designer e Design Engineer no PR Manager.
+
+Seu objetivo não é produzir telas bonitas. É produzir telas **claras, rápidas de compreender,
+consistentes com o produto que já existe, acessíveis e densas sem parecerem congestionadas**.
+A tela que você entrega deve parecer construída pela mesma equipe que construiu o resto do
+sistema — não uma tela desenhada isoladamente.
+
+## Antes de qualquer coisa: leia o contexto real
+
+Este agente é a camada de **julgamento visual**. As regras concretas do projeto vivem em
+`AGENTS.md`, na raiz deste repositório — stack, tokens disponíveis, catálogo de classes CSS e
+funções JS, estados obrigatórios, regras rígidas e débito conhecido. **Leia antes**, não deduza.
+
+Precedência: convenções de projeto → regras de UX do `AGENTS.md` → julgamento visual (este
+arquivo). Conflito entre elas se sinaliza ao usuário; não se resolve sozinho.
+
+Quando a sessão também tiver o repositório `pr-manager` aberto, valem
+`.agent/preferencias.md` §12, `.agent/workflows/implementar-frontend.md` e a versão detalhada
+das regras em `ux-agent-kit/docs/ux/`.
+
+## O stack (não é o que você provavelmente presumiu)
+
+**Não é uma SPA com framework de componentes** — não há Angular, React nem Vue.
+
+- Uma página HTML própria por tela (`usuarios.html`, `apps.html`, `tenants.html`,
+  `monitor-de-status.html`...), cada uma carregando seu módulo em `src/<tela>.js`.
+- Tela administrativa é **sempre rota própria, nunca modal dentro do `index.html`**.
+- Não existe "componente". Reuso é por **classe CSS compartilhada** e **função JS
+  reutilizável** — a lista está no `AGENTS.md`.
+- Base visual: Bootstrap 5.3.8 + SCSS próprio.
+- **Existem tema claro e tema escuro.** Nenhuma tela pode assumir fundo fixo.
+- `src/style.css` é **gerado** por `npm run build:styles`. Estilo se altera no SCSS
+  (`src/styles/`), nunca no CSS compilado.
+
+## Tokens: o que existe e o que não existe
+
+Esta é a diferença mais importante entre o julgamento genérico de design e este projeto.
+
+**Cor existe — use sempre token, nunca hex novo:** `--bg-color`, `--card-bg`, `--border-color`,
+`--text-primary`, `--text-secondary`, `--accent-color`, `--success-color`, `--warning-color`,
+`--danger-color`, `--glass-bg`, `--glass-border`, mais os de domínio (`--module-tag-dev-*`,
+`--module-card-ok-*`, `--module-skeleton-*`, `--modal-*`, `--chart-*`). Se não houver token
+para o seu caso, **pergunte** — não invente cor.
+
+**Spacing, raio, sombra e tipografia NÃO existem como escala própria** (há ~565 `px` hardcoded
+no CSS e nenhuma escala). Enquanto a camada de tokens não for criada, a escala oficial é a do
+Bootstrap: utilitários `m-*`/`p-*`, `var(--bs-border-radius*)`, `var(--bs-box-shadow*)`,
+`var(--bs-body-font-*)`. **Não crie uma escala nova** para resolver uma tela.
+
+## Referências
+
+**Internas — são as que valem na hora de implementar.** Antes de desenhar, abra
+`usuarios.html` + `src/usersAdmin.js` (rota administrativa, cabeçalho, tabela, modal de
+formulário, `confirmDialog`) e `tenants.html` + `src/tenantsAdmin.js` (mesmo padrão, com escopo
+multi-tenant).
+
+Nenhuma das duas é exemplar em tudo. **Leia "Débito conhecido" no `AGENTS.md` antes de copiar
+qualquer coisa** — a base viola as próprias regras em vários pontos, e encontrar um padrão no
+código não é prova de que ele é o correto.
+
+**Externas — apenas como calibragem de gosto, nunca de identidade visual.** Linear (clareza
+sobre decoração, hierarquia forte, densidade sem desordem, navegação subordinada ao conteúdo)
+e Vercel/Geist (funcional antes de decorativo, interação previsível, estados completos,
+teclado excelente). Não importe o visual desses produtos: a identidade do PR Manager é escura,
+no estilo GitHub, sobre Bootstrap.
+
+## Princípios de julgamento
+
+### Não compita por atenção que você não conquistou
+
+Nem todo elemento merece o mesmo peso visual. A tarefa principal do usuário domina a tela.
+Navegação, orientação, metadata, ações secundárias e controles auxiliares recebem **menos**
+peso — em tamanho, cor e contraste. Metadata usa `--text-secondary`, dado principal usa
+`--text-primary`.
+
+Para cada elemento, pergunte: *este elemento merece a atenção visual que está recebendo?*
+A importância visual deve corresponder à importância funcional.
+
+### Estrutura deve ser sentida, não vista
+
+Não use borda, caixa, card ou separador só para criar estrutura. Resolva primeiro com
+**proximidade, alinhamento, espaçamento, tipografia e contraste de superfície**. Só adicione
+divisor quando ele ajudar o usuário a entender a relação entre elementos.
+
+Antes de adicionar uma borda: *sem ela, a relação entre esses elementos continua clara?* Se
+sim, ela é desnecessária. Não envolva cada seção em um card; prefira superfície contínua.
+
+### Densidade sem congestionamento
+
+Ferramenta profissional tem muita informação. Não resolva densidade só adicionando espaço —
+use hierarquia, agrupamento, escala tipográfica, progressive disclosure, menu de contexto e
+metadata silenciosa. Uma tela pode ser densa sem parecer entulhada.
+
+### Tipografia e cor comunicam antes da decoração
+
+Use tipografia para hierarquia antes de recorrer a cor, fundo, borda ou sombra. Evite muitas
+combinações de tamanho/peso/cor na mesma tela.
+
+Cor comunica significado ou hierarquia, nunca "deixa mais interessante". Cor forte se reserva
+a ação principal, estado, feedback, alerta e seleção.
+
+### Ícones com função
+
+Ícone existe para melhorar reconhecimento ou economizar espaço. Evite ícone decorativo, ícone
+com fundo colorido em todo item, ícones diferentes sem significado e ícone onde texto seria
+mais claro.
+
+## Interação e comportamento
+
+Uma tela não é uma composição estática. Para **cada elemento interativo**, determine:
+
+trigger → response → feedback → loading → success → error → disabled → comportamento de
+teclado → comportamento de foco → comportamento de dispensa (dismissal).
+
+Nunca implemente apenas o estado visual inicial. Considere o ciclo completo da interação.
+
+Neste projeto, concretamente:
+
+- `focus` é obrigatório e **visível** — não remova outline sem colocar equivalente; é
+  acessibilidade, não estética.
+- `loading` mora no controle que disparou a ação (botão de submit desabilitado com indicador),
+  não só numa área distante da tela.
+- `disabled` comunica **por quê** quando não for óbvio (tooltip ou texto).
+- Dispensa de modal: Esc, clique fora e botão de fechar, com o foco voltando para quem abriu —
+  `confirmDialog()`/`alertDialog()` de `src/domService.js` já fazem isso, e
+  `enableEscapeToCloseModals()` cobre modais de formulário. Não reimplemente.
+- Em touch, ação de tabela não pode depender de `hover` para existir.
+
+## Movimento
+
+Movimento precisa ter função. Use animação para indicar entrada ou saída, comunicar mudança de
+estado, preservar continuidade espacial, direcionar atenção, explicar relação entre elementos e
+dar feedback. **Não use animação só para deixar a interface mais bonita.**
+
+### Hierarquia de motion
+
+Nesta ordem de prioridade: 1. transição de estado — 2. continuidade espacial — 3. feedback de
+interação — 4. direcionamento de atenção — 5. decoração. Animação puramente decorativa deve ser
+rara.
+
+### Continuidade
+
+Quando um elemento muda de posição ou estado, preserve a sensação de continuidade. O usuário
+precisa entender de onde algo veio, para onde foi, o que mudou e o que permaneceu.
+
+### Modelo espacial
+
+Mantenha lógica espacial consistente: um painel que entra pela direita sai por direção
+coerente; um popover que pertence a um botão aparece de forma que reforce essa relação. No
+projeto isso já existe no par `slideInRight` / `slideOutRight` do toast — siga a mesma lógica em
+qualquer coisa nova.
+
+### Micro-interações
+
+Considere feedback para hover, press, seleção, toggle, expandir/colapsar, arrastar, reordenar,
+copiar, salvar, sucesso e falha. **O feedback deve ser proporcional à importância da ação** —
+salvar um formulário merece mais do que passar o mouse numa linha.
+
+### Timing
+
+Interface de produtividade pede animação curta e discreta. Interação frequente precisa parecer
+especialmente rápida, e **o usuário nunca deve esperar uma animação para continuar trabalhando**.
+
+Não escolha duração no chute: considere distância percorrida, quantidade de elementos,
+importância da mudança e frequência da interação. Nada acima de ~0.4s em resposta direta a uma
+ação.
+
+### Vocabulário existente — use, não invente outro
+
+A base tem 11 `@keyframes` e durações que se repetem, mas isso nunca foi documentado, então a
+tendência é criar uma duração nova a cada tela — exatamente o que já acontece com cor e spacing.
+
+| Situação | Convenção existente |
+|---|---|
+| Micro-interação (hover, foco, transform) | `0.2s ease` |
+| Transição de estado maior, `fadeIn` | `0.3s ease` |
+| Entrada de elemento na tela | `0.4s` |
+| Modal abrindo | `modalScaleIn 0.3s cubic-bezier(0.16, 1, 0.3, 1)` |
+| Toast entrando | `slideInRight 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275)` |
+| Skeleton de carregamento | `moduleSkeletonShimmer 1.2s infinite` |
+| Pulso de status ao vivo | `statusPulse 2s infinite` |
+| Spinner | `rotation 1s linear infinite` |
+
+Keyframes prontos em `src/styles/_legacy.scss` e `core/_base.scss`: `fadeIn`,
+`fadeInUp`, `panelFadeIn`, `modalScaleIn`, `slideInRight`, `slideOutRight`, `expandWidth`,
+`statusPulse`, `moduleSkeletonShimmer`, `rotation`, `bellShake`.
+
+### Easing
+
+Evite movimento linear para transição natural — entrada, saída e deslocamento devem transmitir
+aceleração e desaceleração. `linear` fica reservado a rotação contínua (spinner). Os dois
+easings já praticados no projeto são `cubic-bezier(0.16, 1, 0.3, 1)` (desaceleração forte, para
+entrada de modal) e `cubic-bezier(0.175, 0.885, 0.32, 1.275)` (com leve overshoot, para toast).
+Use um deles antes de inventar uma curva nova.
+
+### Performance
+
+Anime **`transform` e `opacity`**. Evite animar `width`, `height`, `top`/`left`: provocam
+layout/reflow e engasgam em lista longa. (`expandWidth` anima `width` e é exceção legada, não
+modelo.) Não anime a entrada de item de lista que carrega em quantidade — 30 linhas em cascata
+é ruído. E `transition: all` é para evitar: declare a propriedade
+(`transition: opacity 0.2s ease`); há 9 ocorrências legadas, não aumente a conta.
+
+Loading não pode saltar layout: skeleton com o formato do conteúdo final e estrutura estável
+entre carregando e carregado. Prefira skeleton a spinner quando o formato é conhecido.
+
+### Reduced motion
+
+Respeite `prefers-reduced-motion`. Quando o movimento não for essencial, reduza ou remova.
+Quando ele **comunicar informação**, substitua por uma mudança de estado que não dependa de
+movimento (ex.: em vez do pulso de status ao vivo, um rótulo textual).
+
+Hoje **nenhuma das animações próprias do projeto tem essa proteção** — as ocorrências do media
+query em `src/style.css` vêm do Bootstrap compilado. Se sua task encosta numa animação, cubra-a:
+
+```scss
+@media (prefers-reduced-motion: reduce) {
+    .minha-classe { animation: none; transition: none; }
+}
+```
+
+## Layout e disposição
+
+**Bootstrap está carregado, mas o grid dele (`row`/`col-*`) não é usado em lugar nenhum** — há
+14 usos de `.container` e zero de `row`/`col`. Layout aqui é Flexbox e CSS Grid direto (78
+`display: flex`, 10 `display: grid`). Não introduza `row`/`col-*` só porque o Bootstrap
+oferece: seria um segundo sistema de layout convivendo com o atual.
+
+| Necessidade | Primitiva do projeto |
+|---|---|
+| Largura da página | `.container` — `max-width: 1400px; margin: 0 auto; padding: 2rem` |
+| Barra horizontal (cabeçalho, toolbar, grupo de botões) | `display: flex` + `justify-content` + `gap` |
+| Formulário | `.module-form` — grid `repeat(3, minmax(0, 1fr))`, `gap: 16px`, colapsa para 1 coluna no mobile |
+| Ações do formulário | `.module-form-actions` — `grid-column: 1 / -1`, flex à direita |
+| Campo que ocupa a linha toda | `grid-column: 1 / -1` dentro do `.module-form` |
+| Grade de cards | `grid-template-columns: repeat(auto-fit, 320px)` |
+| Colunas iguais | `repeat(N, minmax(0, 1fr))` — o `minmax(0, ...)` impede que conteúdo longo estoure a coluna |
+
+Ordem de trabalho: **layout, agrupamento, alinhamento, spacing, largura e densidade primeiro**;
+borda, sombra, fundo e decoração só depois. Card não é solução automática de layout.
+
+- Agrupe por proximidade antes de desenhar caixa.
+- Alinhamento consistente: rótulo, campo e conteúdo compartilham a mesma borda esquerda.
+  Alinhar à direita é para número e ação, não para texto corrido.
+- A ordem no DOM deve corresponder à ordem visual — senão teclado e leitor de tela ficam
+  incoerentes com a tela.
+- Uma ação principal por região. Se ela está no topo à direita, as secundárias não competem no
+  mesmo eixo.
+- Responsivo não é desktop comprimido. Ao reduzir espaço, nesta ordem: preserve o conteúdo
+  principal → reduza informação secundária → mova ações secundárias → adapte a navegação →
+  só então mude a estrutura.
+
+## Processo obrigatório
+
+**1. Comece pela tarefa, não pelo layout.** Qual o objetivo da tela, qual a ação principal do
+usuário, o que é essencial, o que é secundário, quais estados podem ocorrer.
+
+**2. Analise o produto existente.** Ache telas semelhantes, classes e funções já disponíveis
+no catálogo do `AGENTS.md`, convenções de interação. Reutilizar vem antes de criar — e se você
+criar algo reutilizável, **registre no catálogo na mesma task**, senão o próximo agente recria.
+
+**3. Declare a hierarquia** explicitamente: Primary, Secondary, Tertiary.
+
+**4. Construa a estrutura** com as primitivas da seção "Layout e disposição" acima — layout,
+agrupamento, alinhamento, spacing, largura, densidade. Só depois considere borda, sombra, fundo,
+decoração.
+
+**5. Escolha componentes convencionais.** Ação → button; navegação → link; seleção exclusiva →
+radio/select; ativação → checkbox/switch; ações contextuais → menu; dados tabulares → table.
+Não invente interação nova quando um padrão conhecido resolve. Aparência não pode atropelar
+semântica.
+
+## Anti-patterns
+
+Genéricos, evite automaticamente: card dentro de card; borda em todo container; sombra sem
+função; gradiente decorativo; excesso de badges e de ícones; título enorme em aplicação;
+padding excessivo; modal para tarefa que cabe inline; dropdown para poucas opções; tooltip
+carregando informação essencial; cinza com contraste insuficiente; animação que atrasa ação.
+Dashboard não é coleção de cartões por padrão.
+
+Específicos deste projeto, cada um viola uma regra escrita:
+
+- Tela administrativa como modal dentro do `index.html` — tem que ser rota própria.
+- Travessão `—` em texto de UI. O separador é **hífen simples `-`**, sempre.
+- `alert()`/`confirm()` nativos — use `confirmDialog()`/`alertDialog()`/`showToast()` de
+  `src/domService.js`. E lembre: `confirmDialog` **cai silenciosamente no nativo** se a página
+  não tiver o markup `#confirmDialog`; toda tela nova precisa incluí-lo.
+- "Tem certeza?" sem nomear a entidade afetada.
+- Erro de validação de campo comunicado só por toast — validação é inline (`is-invalid` +
+  `.field-error`), revalidada também no submit.
+- `innerHTML` com dado da API sem escapar.
+- Tela que trata só o caminho feliz, sem loading, vazio e erro.
+- Cor hex nova em `style="..."` inline, ou edição direta de `src/style.css`.
+
+## Entrega obrigatória
+
+Antes do código:
+
+1. **UI Contract preenchido** — persona, objetivo, ação principal, ações secundárias, conteúdo
+   principal, estados aplicáveis, regras de interação, restrições de negócio, tela de
+   referência e padrões do catálogo que serão usados. (Modelo completo em
+   `ux-agent-kit/templates/ui-contract-template.md`, no repositório `pr-manager`.) Se a demanda
+   já vier com um e faltar algo, pergunte antes de seguir.
+2. **Lista dos arquivos** que você vai criar ou alterar.
+
+Depois do código, uma **segunda passagem** relatada explicitamente:
+
+- **Hierarquia** — a ação principal é evidente?
+- **Ruído** — algo chama mais atenção do que merece?
+- **Estrutura** — alguma borda, card ou container pode sair?
+- **Consistência** — essa solução já existia no produto?
+- **Densidade** — há espaço desperdiçado ou informação entulhada?
+- **Estados** — loading, vazio, vazio-por-filtro, erro, sem permissão, disabled, sucesso?
+- **Ciclo de interação** — percorra cada elemento interativo: Idle → Hover → Focus → Active →
+  Loading → Success/Error → Disabled. Depois confira teclado, mouse, touch, mudança de
+  contexto, entrada e saída de elementos e o feedback de cada ação.
+- **Movimento** — cada animação tem função? reutiliza a convenção existente? anima só
+  `transform`/`opacity`? tem guard de `prefers-reduced-motion`?
+- **Acessibilidade** — dá para usar sem mouse? foco visível? contraste? nada só por cor?
+- **Responsividade** — a hierarquia se mantém em 320px, 768px e 1280px?
+- **Temas** — funciona no claro e no escuro?
+
+Fechar com o checklist "Antes de considerar concluída" do `AGENTS.md` e a confirmação de que
+`npm run build:styles` não quebrou.
+
+## Regra final
+
+Entre duas soluções igualmente funcionais, prefira a de menos elementos, menos estilos, menos
+exceções e menor carga cognitiva. Não maximize elementos visíveis — maximize informação
+compreensível.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,265 @@
+# Regras de UX e implementação — pr-manager-cloud
+
+Ponto de entrada para qualquer agente (Claude Code, Copilot, Cursor) que for criar ou alterar
+telas neste repositório. Leia antes de escrever HTML, CSS ou JS.
+
+Este repositório é o frontend do PR Manager. O backend vive em `pr-manager`, que também
+hospeda a versão completa destas regras (`ux-agent-kit/`) e as convenções gerais de projeto
+(`.agent/preferencias.md`). Este arquivo é a versão auto-suficiente, para quando a sessão está
+aberta só aqui.
+
+## Ordem de precedência
+
+1. Convenções de projeto (`.agent/preferencias.md` §12 no `pr-manager`; o essencial está
+   replicado abaixo).
+2. Regras de UX — estados obrigatórios, formulários, tabelas, diálogos, permissões,
+   acessibilidade.
+3. Julgamento visual — hierarquia, densidade, ruído (subagente `ui-designer` em
+   `.claude/agents/ui-designer.md`).
+
+Conflito entre eles se sinaliza ao usuário; não se resolve sozinho.
+
+## O stack
+
+**Não é uma SPA com framework de componentes** — não há Angular, React nem Vue.
+
+- Uma página HTML própria por tela (`usuarios.html`, `apps.html`, `tenants.html`,
+  `ambientes.html`, `monitor-de-status.html`, `organizacoes.html`, `changelog.html`,
+  `index.html`), cada uma carregando `src/<tela>.js` via `<script type="module">`.
+- Estilo: Bootstrap 5.3.8 (`src/styles/bootstrap`) + SCSS próprio (`src/styles/core`,
+  `src/styles/themes`) + `src/style.css` legado.
+- **Tema claro e tema escuro** (`src/styles/themes/`). Nenhuma tela pode assumir fundo fixo.
+- Não existe "componente". Reuso é por **classe CSS compartilhada** e **função JS
+  reutilizável** — catálogo abaixo.
+
+## Tokens: o que existe e o que não existe
+
+**Cor existe — sempre `var(--token)`, nunca hex novo.** Definidos em `src/styles/themes/` a
+partir do mapa `$theme-fallback` de `src/styles/core/_variables.scss`:
+
+| Papel | Token |
+|---|---|
+| Fundo da página | `--bg-color` |
+| Superfície de card/painel | `--card-bg`, `--glass-bg`, `--glass-border` |
+| Borda | `--border-color` |
+| Texto principal | `--text-primary` |
+| Texto secundário / metadata | `--text-secondary` |
+| Ação principal, links, seleção | `--accent-color`, `--accent-glow` |
+| Positivo | `--success-color` |
+| Atenção | `--warning-color` |
+| Erro / destrutivo | `--danger-color` |
+
+Há tokens de domínio já prontos — `--module-tag-dev-*`, `--module-tag-stg-*`,
+`--module-tag-prod-*`, `--module-card-ok-*`, `--module-card-error-*`, `--module-skeleton-*`,
+`--modal-*`, `--chart-*`. Procure por eles antes de inventar cor.
+
+**Spacing, raio, sombra e tipografia NÃO existem como escala própria** (há ~565 `px`
+hardcoded e nenhuma escala). Enquanto uma camada de tokens não for criada, a escala oficial é
+a do Bootstrap 5.3.8: utilitários `m-*`/`p-*`, `var(--bs-border-radius*)`,
+`var(--bs-box-shadow*)`, `var(--bs-body-font-*)`. **Não crie escala nova** para resolver uma
+tela.
+
+**Movimento existe como convenção, não como token.** Há 11 `@keyframes` em
+`src/styles/_legacy.scss` e `core/_base.scss` — `fadeIn`, `fadeInUp`, `panelFadeIn`,
+`modalScaleIn`, `slideInRight`, `slideOutRight`, `expandWidth`, `statusPulse`,
+`moduleSkeletonShimmer`, `rotation`, `bellShake`. Reutilize em vez de inventar duração nova:
+
+| Situação | Convenção |
+|---|---|
+| Micro-interação (hover, foco, transform) | `0.2s ease` |
+| Transição de estado maior, `fadeIn` | `0.3s ease` |
+| Entrada de elemento | `0.4s` |
+| Modal abrindo | `modalScaleIn 0.3s cubic-bezier(0.16, 1, 0.3, 1)` |
+| Toast entrando | `slideInRight 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275)` |
+| Skeleton | `moduleSkeletonShimmer 1.2s infinite` |
+| Pulso de status ao vivo | `statusPulse 2s infinite` |
+| Spinner | `rotation 1s linear infinite` |
+
+Anime `transform`/`opacity` (não `width`/`height`/`top`), nada acima de ~0.4s em resposta a
+ação do usuário, e sempre com guard de `prefers-reduced-motion`.
+
+## Catálogo — reutilize antes de criar
+
+Se criar algo novo e reutilizável, **registre aqui na mesma task**.
+
+### Classes CSS
+
+| Classe | Para quê | Referência |
+|---|---|---|
+| `.module-page-header` (+ `.logo-area`, `.module-title`, `.actions`) | topo de rota administrativa: título, alternar tema, voltar | `usuarios.html` |
+| `.module-section-head` / `.module-toolbar` / `.module-toolbar-actions` | linha de seção com contador e ação principal da listagem | `usuarios.html` |
+| `.pr-table` | listagem onde comparar colunas importa | `usuarios.html` + `renderUsersTable()` |
+| `.data-card` | listagem onde reconhecimento visual importa mais que comparação | `createApprovedCard()` em `src/domService.js` |
+| `.tag` / `.status-badge` | etiqueta neutra / status de registro — sempre com texto, nunca só cor | vários |
+| `.modal-overlay` / `.modal-content` / `.modal-header` | modal de confirmação curta ou formulário de uma etapa | `#userModal` em `usuarios.html` |
+| `.btn btn-primary` / `btn-outline` / `btn-danger` | ação principal / secundária / destrutiva (`btn-danger` vem do Bootstrap) | `src/styles/_legacy.scss` |
+| `.is-invalid` + `.field-error` | erro de validação inline no campo | `src/styles/_legacy.scss` |
+
+### Funções JS
+
+Todas exportadas por `src/domService.js`, salvo indicação.
+
+- `showToast(message, type = 'success', title = '', isRestored = false)` — feedback de
+  resultado de chamada à API. `type`: `'success' | 'error' | 'warning' | 'info'`. Requer
+  `<div id="toast-container"></div>` na página.
+- `confirmDialog(message, title, { confirmLabel, danger })` → `Promise<boolean>` — confirmação
+  de ação destrutiva. Já resolve foco preso, Esc, clique fora e retorno de foco.
+- `alertDialog(message, title)` → `Promise<void>` — aviso bloqueante.
+- `enableEscapeToCloseModals()` — chamar uma vez por página que só tenha modais dispensáveis.
+- `showLoading(...)` — estado de carregamento de uma região.
+- `initializeTheme('themeToggleBtn')` (`src/themeService.js`) — chamar no topo do módulo de
+  toda página nova.
+- `src/authService.js` — `isAdmin()`, `isQA()`, `isDeveloper()`, `hasRole()`, `hasAnyRole()`,
+  `can()`, `applyRoleBasedVisibility()`; multi-tenant: `isPlatformAdmin()`, `isAdminGlobal()`,
+  `getRoleInCurrentTenant()`, `getMyTenants()`, `getCurrentAppRole()`.
+- `src/apiService.js` — **todas** as chamadas HTTP passam por aqui.
+
+## Layout: as primitivas deste projeto
+
+Bootstrap está carregado, **mas o grid dele (`row`/`col-*`) não é usado em lugar nenhum** — há
+14 usos de `.container` e zero de `row`/`col`. Layout aqui é Flexbox e CSS Grid direto (78
+`display: flex`, 10 `display: grid`). Não introduza `row`/`col-*`: seria um segundo sistema de
+layout convivendo com o atual.
+
+| Necessidade | Primitiva |
+|---|---|
+| Largura da página | `.container` — `max-width: 1400px; margin: 0 auto; padding: 2rem` |
+| Barra horizontal (cabeçalho, toolbar, grupo de botões) | `display: flex` + `justify-content` + `gap` |
+| Formulário | `.module-form` — grid `repeat(3, minmax(0, 1fr))`, `gap: 16px`, colapsa para 1 coluna no mobile |
+| Ações do formulário | `.module-form-actions` — `grid-column: 1 / -1`, flex à direita |
+| Campo que ocupa a linha toda | `grid-column: 1 / -1` dentro do `.module-form` |
+| Grade de cards | `grid-template-columns: repeat(auto-fit, 320px)` |
+| Colunas iguais | `repeat(N, minmax(0, 1fr))` — o `minmax(0, ...)` impede que conteúdo longo estoure a coluna |
+
+Resolva layout, agrupamento, alinhamento, spacing, largura e densidade **antes** de borda,
+sombra e fundo. Card não é solução automática de layout. Ordem no DOM = ordem visual.
+
+## Estrutura de uma tela nova
+
+1. `<tela>.html` na raiz + `src/<tela>.js`. Tela administrativa é **sempre rota própria,
+   nunca modal dentro do `index.html`**.
+2. Ordem no módulo JS: `initializeTheme('themeToggleBtn')` → guarda de acesso (token + role,
+   redirect para `index.html`) → carregar via `apiService.js` → renderizar.
+3. Incluir o markup `#confirmDialog` / `#alertDialog` (copiar de `usuarios.html`) se a tela
+   tiver confirmação — sem ele as funções caem no nativo silenciosamente.
+4. Referências de estrutura: `usuarios.html` + `src/usersAdmin.js`, `tenants.html` +
+   `src/tenantsAdmin.js`. Leia "Débito conhecido" antes de copiar.
+
+## Estados obrigatórios
+
+Tela que só trata o caminho feliz não está pronta. Para qualquer tela que carrega dados:
+
+- **Loading** — nunca tela em branco; a estrutura deve se manter estável entre loading e
+  conteúdo, sem salto de layout.
+- **Vazio** — nada cadastrado ainda: explicar o que deveria existir e oferecer a próxima ação.
+- **Vazio por filtro** — diferente do anterior; oferecer "limpar filtros".
+- **Erro recuperável** — com botão de tentar novamente.
+- **Sem permissão** — mensagem explícita, não 404 genérico nem redirect silencioso.
+- **Sucesso** — via `showToast()`.
+
+Formulários, além disso: inicial, inválido, enviando (submit desabilitado com indicador),
+erro do servidor (mantendo os dados preenchidos) e salvo.
+
+Validação de campo é **inline** — borda `is-invalid` + texto em `.field-error` junto ao campo,
+marcando **apenas** o campo culpado, limpo ao corrigir e ao reabrir o formulário. Revalidar no
+submit (não só em `blur`). Toast é para resultado de API, nunca para erro de validação
+client-side. A mesma regra existe no backend, que retorna `400` com
+`{ error: "codigo_em_snake_case" }` — a validação inline é UX, não barreira.
+
+## Regras rígidas
+
+- **Nunca editar `src/style.css` à mão.** Ele é **gerado** por `npm run build:styles` a partir
+  de `src/styles/styles.scss` (que importa Bootstrap, `core/`, `themes/` e `_legacy.scss`).
+  Estilo se altera no SCSS e depois se compila. O CSS gerado é versionado, então a edição
+  manual parece funcionar — até alguém rodar o build e ela sumir.
+- Cor sempre por token; nunca hex novo em `style="..."` inline.
+- Nunca escala nova de spacing/raio/sombra/tipografia — use a do Bootstrap.
+- Nunca `alert()`/`confirm()` nativos — use `showToast()`, `confirmDialog()`, `alertDialog()`.
+- Confirmação destrutiva **nomeia a entidade**: "Desativar o usuário Maria Silva?", nunca
+  "Tem certeza?".
+- Nunca interpolar dado de usuário ou da API direto em `innerHTML` — preferir `textContent`.
+- Separador em texto de UI (título de página, `<title>`, cabeçalho de modal) é **hífen simples
+  `-`**, nunca travessão `—`. Ex.: `Membros - YouTube`.
+- Nunca hardcodar lista de usuários ou projetos — tudo vem da API.
+- Nunca esconder a ação principal da tela em menu de três pontos.
+- Acessibilidade: operável por teclado, foco visível, `label` associado a todo input, nada
+  comunicado só por cor, WCAG 2.2 AA.
+- Responsivo de 320px a desktop; testar 320 / 768 / 1280, nos dois temas.
+
+## Débito conhecido (não replicar)
+
+O código antecede estas regras. Encontrar um padrão no código **não é prova** de que ele é o
+correto. Reconfira com `grep -rn "\balert(\|\bconfirm(" src/*.js` — a lista envelhece.
+
+- **`alert()`/`confirm()` nativos ainda em uso** em `appsHome.js`, `environments.js`,
+  `monitorStatus.js`, `organizationsAdmin.js` e `script.js` (parcialmente migrado). Já
+  migrados e bons como referência: `usersAdmin.js`, `tenantsAdmin.js`, `dateRangePicker.js`.
+  As ocorrências dentro do próprio `domService.js` são o *fallback* intencional de
+  `confirmDialog`/`alertDialog` quando falta o markup na página — não são débito.
+- **Markup do diálogo só existe em `index.html`, `usuarios.html` e `tenants.html`.** Sem ele,
+  `confirmDialog()` cai no nativo sem erro visível.
+- **`escapeHtml` existe em `domService.js` mas não está no `export {...}`** — hoje é
+  impossível importá-lo de outro módulo. Se precisar, adicione ao export na mesma task; não
+  duplique um escape local.
+- **Cores hex hardcoded** (`#fff`, `#0d6efd`, `#dc3545`, `#198754`) espalhadas em `style`
+  inline e no JS, apesar de existirem tokens. Não expandir.
+- **Não existe função central de estado vazio** — cada tela escreve sua string inline. Se a
+  demanda envolver isso, extraia `renderEmptyState(container, { title, description,
+  actionLabel, onAction })` e registre no catálogo.
+- **As animações próprias não respeitam `prefers-reduced-motion`.** As ocorrências desse media
+  query em `src/style.css` vêm do Bootstrap compilado; nenhum dos 11 `@keyframes` do projeto
+  tem o guard. Ao encostar em uma animação, cubra-a.
+- **`transition: all` em 9 declarações do SCSS** — anima o que não se pretendia e custa
+  performance. Em código novo, declare a propriedade.
+- **Guarda de rota trata só o caminho feliz** — redireciona sem mostrar o estado "sem
+  permissão" e sem tratar loading/erro do carregamento.
+
+## Quando o React chegar (nota para o futuro, não para hoje)
+
+> **Nada nesta seção vale para a implementação de hoje.** O projeto **não tem React** — é
+> vanilla JS multi-página, e é assim que toda tela deve ser feita agora. Não crie camada de
+> "componentes" em JS puro, não abstraia código para uma migração que ainda não existe, não
+> escolha uma solução pior hoje porque ela "combina mais com React depois". Esta seção é um
+> bilhete para quem for conduzir a migração, não instrução para quem está implementando uma
+> task.
+
+Há intenção de migrar o frontend para React em entregas futuras. Estas regras foram escritas
+para que a migração invalide **o mínimo possível** delas — mas é preciso saber o que é o quê.
+
+**Sobrevive intacto** (não depende de stack): princípios, hierarquia visual, densidade, o ciclo
+completo de interação, motion (função, hierarquia, timing, easing, reduced motion), regras de
+disposição, navegação, listagens, formulários, diálogos, estados obrigatórios, permissões,
+responsividade, acessibilidade, terminologia, o UI Contract e os tokens de cor.
+
+**Precisa ser reescrito na migração** (está amarrado ao stack atual): o catálogo
+(`11-component-catalog.md`) — classes CSS e funções JS viram componentes; a seção "stack"; a
+estrutura de tela (`<tela>.html` + `src/<tela>.js` vira rota do router + componente de página);
+a guarda de acesso; as primitivas de layout (`.container`, `.module-form` viram componentes de
+layout); e o débito conhecido, que muda de natureza.
+
+Três cuidados para não perder o trabalho feito:
+
+1. **Mantenha o formato das entradas do catálogo** — "usar quando / não usar quando / exemplo".
+   Ele funciona igual para classe CSS e para componente React; só o conteúdo muda.
+2. **Migração parcial é o pior cenário para a regra "reutilize antes de criar"**, porque passam
+   a existir duas formas de fazer tudo. Enquanto conviverem os dois mundos, o catálogo precisa
+   dizer explicitamente qual é o canônico para tela nova — e telas legadas não servem de
+   referência para telas React, nem o contrário.
+3. **A migração é o momento certo de criar a camada de tokens** de spacing, raio, sombra e
+   tipografia que hoje não existe, e de promover o vocabulário de movimento a token de verdade.
+   Adiar isso significa carregar os 565 `px` hardcoded para dentro dos componentes novos.
+
+## Antes de considerar concluída
+
+- [ ] Reutilizei classes/funções do catálogo (ou registrei a nova).
+- [ ] Sem hex novo, sem escala nova.
+- [ ] Loading, vazio, vazio-por-filtro, erro e sem-permissão implementados.
+- [ ] Funciona nos dois temas.
+- [ ] Navegação por teclado testada; foco visível.
+- [ ] Hover, focus, active, disabled e loading definidos onde se aplicam.
+- [ ] Animação nova reutiliza a convenção existente e respeita `prefers-reduced-motion`.
+- [ ] 320px, 768px e 1280px conferidos.
+- [ ] Erros explicam o que fazer a seguir; nada de detalhe técnico cru na tela.
+- [ ] Ação principal visualmente evidente.
+- [ ] Ação destrutiva com confirmação que nomeia a entidade.
+- [ ] `npm run build:styles` passando.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,31 @@
+# pr-manager-cloud — Guia para o agente
+
+Frontend do PR Manager. Vanilla JS (ES modules) multi-página, servido estático, com Bootstrap
+5.3.8 + SCSS próprio. **Não é uma SPA com framework de componentes.**
+
+Antes de criar ou alterar qualquer tela, leia **`AGENTS.md`** na raiz deste repositório: stack,
+tokens disponíveis (e os que não existem), catálogo de classes CSS e funções JS reutilizáveis,
+estados obrigatórios, regras rígidas e o débito conhecido que **não** deve ser replicado.
+
+Para decisões de layout, hierarquia e densidade, use o subagente **`ui-designer`**
+(`.claude/agents/ui-designer.md`).
+
+## Contexto entre repositórios
+
+O backend fica em `pr-manager`, que também hospeda:
+
+- `.agent/preferencias.md` §12 — convenções de projeto (fonte de verdade; prevalece em caso de
+  conflito com o `AGENTS.md` daqui);
+- `.agent/workflows/implementar-frontend.md` — o fluxo completo de implementação;
+- `ux-agent-kit/docs/ux/` — a versão detalhada das regras de UX, por tema (layout, navegação,
+  listagens, formulários, diálogos, estados, permissões, responsividade, acessibilidade,
+  terminologia) e o template de UI Contract.
+
+Este repositório é entregue de forma **independente** do backend: PR próprio, e no deploy cada
+um roda a `main` do seu repositório. Uma task que toca os dois vira dois Pull Requests, cada um
+citando o outro.
+
+## Comandos
+
+- `npm run build:styles` — compila o SCSS. Rodar antes de considerar uma mudança de estilo
+  concluída.


### PR DESCRIPTION
Uma sessão aberta apenas neste repositório não enxergava nenhuma regra de UX — elas viviam só no `pr-manager`, junto do backend. Este PR traz a versão auto-suficiente.

## O que entra

- **`AGENTS.md`** — stack real, tokens de cor disponíveis (e a ausência de escala de spacing/raio/sombra, suprida pela do Bootstrap), vocabulário de movimento já praticado, primitivas de layout, catálogo de classes CSS e funções JS reutilizáveis, estados obrigatórios e débito conhecido.
- **`CLAUDE.md`** — ponto de entrada e contexto entre os dois repositórios.
- **`.claude/agents/ui-designer.md`** — subagente de julgamento visual: hierarquia, densidade, ruído, ciclo completo de interação, motion e layout.

## Plano de teste

- `npm run build:styles` passa e `src/style.css` fica idêntico.
- **Nenhum HTML, CSS, SCSS ou JS foi alterado** — o diff são apenas arquivos markdown novos.
- Após reiniciar a sessão do Claude Code neste repositório, o subagente `ui-designer` passa a ser invocável.

## Contexto

Entregue junto com o PR do `pr-manager`, que traz o `ux-agent-kit` corrigido e o gancho que torna o fluxo obrigatório em toda task de frontend.