### PR TITLE
fix: ajusta ajuda quando a aplicação não é encontrada

### DIFF
--- a/index.html
+++ b/index.html
@@ -392,7 +392,7 @@
                             <a id="projectEmptyAdminLink" href="apps.html?new=1" style="display: none;">Cadastrar aplicação</a>
                         </div>
                         <div id="projectHelpTooltip" class="field-help-tooltip" style="display: none;">
-                            Não encontrou a aplicação na lista? Ela precisa estar cadastrada no PR Manager primeiro.
+                            Não encontrou a aplicação na lista? Talvez ela não tenha sido cadastrada.
                             <a href="apps.html?new=1" target="_blank" rel="noopener" data-roles="Admin">Cadastrar aplicação →</a>
                         </div>
                     </div>


### PR DESCRIPTION
## Resumo

- substitui a ajuda do seletor de aplicação pelo texto solicitado
- remove a referência direta ao PR Manager sem alterar layout ou comportamento

## Testes

- npm run build:styles
- npm test — 13 testes aprovados