### PR TITLE
feat: esteira de entrega com matriz de ambientes e vínculos flexíveis

### DIFF
--- a/ambientes.html
+++ b/ambientes.html
@@ -34,6 +34,27 @@
         </section>
 
         <section id="envGrid" class="module-cards"></section>
+
+        <!-- Esteira configurável (Épico 2, D4): nem todo cliente tem os três ambientes.
+             Antes disso, um app sem staging nunca conseguia promover para produção. -->
+        <section class="module-section-head module-toolbar" style="margin-top: 2.5rem;" data-roles="Admin">
+            <div>
+                <h2>Esteira de entrega</h2>
+                <p style="color: var(--text-secondary); margin: 0.25rem 0 0; font-size: 0.85rem;">
+                    A ordem define de onde cada promoção vem. O ambiente de integração recebe PR a
+                    PR, sem versão; os demais recebem versões.
+                </p>
+            </div>
+        </section>
+
+        <section id="pipelineSection" class="entrega-panel" style="margin-bottom: 3rem;" data-roles="Admin">
+            <div id="pipelineEditor" class="pipeline-editor"></div>
+            <div class="field-error" id="pipelineError"></div>
+            <div class="module-form-actions" style="margin-top: 1rem;">
+                <button id="pipelineResetBtn" class="btn btn-outline" type="button">Descartar alterações</button>
+                <button id="pipelineSaveBtn" class="btn btn-primary" type="button">Salvar esteira</button>
+            </div>
+        </section>
     </div>
 
     <!-- Confirmação de promoção stg → prod (modal interno da rota) -->
@@ -50,6 +71,8 @@
             </div>
         </div>
     </div>
+
+    <div id="toast-container" class="toast-container"></div>
 
     <script type="module" src="src/environments.js"></script>
     <script>

--- a/ambientes.html
+++ b/ambientes.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Ambientes - PR Manager</title>
+    <title>Ambientes e esteira - PR Manager</title>
     <link rel="stylesheet" href="src/style.css">
     <link rel="icon" type="image/png" href="favicon.png">
     <script src="https://unpkg.com/lucide@latest"></script>
@@ -12,10 +12,10 @@
 
 <body>
     <div class="container">
-        <header class="module-page-header">
+        <header class="module-page-header env-page-header">
             <div class="logo-area">
                 <div>
-                    <h1 class="module-title">Ambientes</h1>
+                    <h1 class="module-title">Ambientes e esteira</h1>
                     <p id="envAppName" style="color: var(--text-secondary); margin: 0.2rem 0 0;"></p>
                 </div>
             </div>
@@ -33,7 +33,11 @@
             </div>
         </section>
 
-        <section id="envGrid" class="module-cards"></section>
+        <div id="envPageState" class="page-state" role="status" aria-live="polite">
+            <i data-lucide="loader-circle" aria-hidden="true"></i>
+            <span>Carregando ambientes...</span>
+        </div>
+        <section id="envGrid" class="module-cards" aria-live="polite"></section>
 
         <!-- Esteira configurável (Épico 2, D4): nem todo cliente tem os três ambientes.
              Antes disso, um app sem staging nunca conseguia promover para produção. -->
@@ -48,8 +52,11 @@
         </section>
 
         <section id="pipelineSection" class="entrega-panel" style="margin-bottom: 3rem;" data-roles="Admin">
+            <div class="pipeline-editor__header" aria-hidden="true">
+                <span>Ordem</span><span>Ambiente</span><span>Modo</span><span>Branch</span><span>Ações</span>
+            </div>
             <div id="pipelineEditor" class="pipeline-editor"></div>
-            <div class="field-error" id="pipelineError"></div>
+            <div class="field-error" id="pipelineError" role="alert" aria-live="polite"></div>
             <div class="module-form-actions" style="margin-top: 1rem;">
                 <button id="pipelineResetBtn" class="btn btn-outline" type="button">Descartar alterações</button>
                 <button id="pipelineSaveBtn" class="btn btn-primary" type="button">Salvar esteira</button>
@@ -57,17 +64,29 @@
         </section>
     </div>
 
-    <!-- Confirmação de promoção stg → prod (modal interno da rota) -->
-    <div id="promoteModal" class="modal-overlay">
+    <!-- Confirmação de promoção entre degraus configurados (modal interno da rota) -->
+    <div id="promoteModal" class="modal-overlay" role="dialog" aria-modal="true" aria-labelledby="promoteTitle">
         <div class="modal-content" style="max-width: 560px;">
             <div class="modal-header">
-                <h2>Promover para produção</h2>
+                <h2 id="promoteTitle">Promover versão</h2>
                 <button class="close-btn" type="button" aria-label="Fechar">&times;</button>
             </div>
             <div id="promoteSummary" style="margin-bottom: 1rem;"></div>
             <div class="module-form-actions">
                 <button class="btn btn-outline close-modal" type="button">Cancelar</button>
                 <button id="promoteConfirmBtn" class="btn btn-primary" type="button">Promover</button>
+            </div>
+        </div>
+    </div>
+
+    <div id="confirmDialog" class="modal-overlay" role="dialog" aria-modal="true"
+        aria-labelledby="confirmDialogTitle" aria-describedby="confirmDialogMessage" aria-hidden="true">
+        <div class="modal-content" style="max-width: 420px;">
+            <div class="modal-header"><h2 id="confirmDialogTitle">Confirmar ação</h2></div>
+            <p id="confirmDialogMessage" style="color: var(--text-secondary);"></p>
+            <div class="module-form-actions">
+                <button id="confirmDialogNo" class="btn btn-outline" type="button">Cancelar</button>
+                <button id="confirmDialogYes" class="btn btn-primary" type="button">Confirmar</button>
             </div>
         </div>
     </div>

--- a/entrega.html
+++ b/entrega.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html lang="pt-br" data-theme="dark">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Entrega - PR Manager</title>
+    <link rel="stylesheet" href="src/style.css">
+    <link rel="icon" type="image/png" href="favicon.png">
+    <script src="https://unpkg.com/lucide@latest"></script>
+</head>
+
+<body>
+    <div class="container">
+        <header class="module-page-header">
+            <div class="logo-area">
+                <div>
+                    <h1 class="module-title">Entrega</h1>
+                    <p id="entregaSummary" style="color: var(--text-secondary); margin: 0.2rem 0 0;"></p>
+                </div>
+            </div>
+            <div class="actions">
+                <button id="themeToggleBtn" class="btn btn-outline" type="button" title="Alternar tema">
+                    <i data-role="theme-icon" data-lucide="sun"></i>
+                </button>
+                <a href="index.html" class="btn btn-outline">Voltar</a>
+            </div>
+        </header>
+
+        <div id="entregaLoading" style="padding: 2rem; color: var(--text-secondary);">Carregando entrega...</div>
+
+        <div id="entregaError" class="entrega-panel" style="display: none;">
+            <p id="entregaErrorText" style="margin: 0; color: var(--danger-color);"></p>
+        </div>
+
+        <div id="entregaContent" class="entrega-grid" style="display: none;">
+            <div>
+                <section class="entrega-panel">
+                    <h2 class="entrega-panel__title">Situação na esteira</h2>
+                    <div id="entregaMatrix"></div>
+                    <div id="entregaPresenceActions" style="margin-top: 1rem; display: flex; gap: 0.5rem; flex-wrap: wrap;"></div>
+                </section>
+
+                <section class="entrega-panel">
+                    <h2 class="entrega-panel__title">Histórico</h2>
+                    <div id="entregaTimeline"></div>
+                </section>
+            </div>
+
+            <div>
+                <section class="entrega-panel">
+                    <h2 class="entrega-panel__title">Ciclo do PR</h2>
+                    <dl id="entregaCiclo" class="entrega-meta"></dl>
+                </section>
+
+                <section class="entrega-panel">
+                    <h2 class="entrega-panel__title">Vínculos</h2>
+                    <ul id="entregaLinks" class="link-list"></ul>
+
+                    <!-- Vínculo nunca é obrigatório: hotfix e bugfix entram sem task. -->
+                    <form id="linkForm" style="margin-top: 1rem; display: flex; flex-direction: column; gap: 0.5rem;" novalidate>
+                        <div>
+                            <label for="linkKind" class="form-label" style="font-size: 0.8rem;">Tipo</label>
+                            <select id="linkKind" class="form-select form-select-sm">
+                                <option value="Task">Task</option>
+                                <option value="Pr">Pull Request</option>
+                                <option value="Communication">Comunicação</option>
+                                <option value="Pipeline">Pipeline</option>
+                                <option value="Other">Outro</option>
+                            </select>
+                        </div>
+                        <div>
+                            <label for="linkUrl" class="form-label" style="font-size: 0.8rem;">Endereço</label>
+                            <input type="url" id="linkUrl" class="form-control form-control-sm" placeholder="https://...">
+                            <div class="field-error" id="linkUrlError"></div>
+                        </div>
+                        <div>
+                            <label for="linkLabel" class="form-label" style="font-size: 0.8rem;">Rótulo (opcional)</label>
+                            <input type="text" id="linkLabel" class="form-control form-control-sm" maxlength="200">
+                            <div class="field-error" id="linkLabelError"></div>
+                        </div>
+                        <button type="submit" class="btn btn-primary btn-sm">Adicionar vínculo</button>
+                    </form>
+                </section>
+            </div>
+        </div>
+    </div>
+
+    <!-- Revert de presença: sair da branch de integração exige motivo -->
+    <div id="revertModal" class="modal-overlay">
+        <div class="modal-content" style="max-width: 480px;">
+            <div class="modal-header">
+                <h3 id="revertModalTitle">Reverter presença</h3>
+            </div>
+            <div class="modal-body">
+                <p style="color: var(--text-secondary); font-size: 0.9rem;">
+                    Isto registra que o código saiu da branch de integração. Não use para marcar
+                    entrega — o que já chegou em produção some da lista sozinho.
+                </p>
+                <label for="revertReason" class="form-label">Motivo</label>
+                <textarea id="revertReason" class="form-control" rows="3"></textarea>
+                <div class="field-error" id="revertReasonError"></div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-outline" id="revertCancelBtn">Cancelar</button>
+                <button type="button" class="btn btn-primary" id="revertConfirmBtn">Confirmar revert</button>
+            </div>
+        </div>
+    </div>
+
+    <div id="toast-container" class="toast-container"></div>
+
+    <script type="module" src="src/entrega.js"></script>
+</body>
+
+</html>

--- a/index.html
+++ b/index.html
@@ -167,9 +167,21 @@
                         PRs em Aberto <span id="totalOpenPrs" class="tag"
                             style="margin-left: 10px; background: var(--accent-color); color: white; display: none;">0</span>
                     </h3>
-                    <button id="addPrBtn" class="btn btn-primary" title="Novo PR (N)">
-                        <i data-lucide="plus"></i> Novo PR
-                    </button>
+                    <div style="display: flex; align-items: center; gap: 1rem;">
+                        <!-- Épico 2: "em voo" é filtro derivado, não estado gravado. Nada é
+                             apagado — desmarcar traz de volta o que já chegou em produção. -->
+                        <div class="form-check form-switch m-0">
+                            <input class="form-check-input" type="checkbox" role="switch" id="inFlightToggle" checked>
+                            <label class="form-check-label" for="inFlightToggle"
+                                style="color: var(--text-secondary); font-size: 0.85rem; white-space: nowrap;"
+                                title="Esconde o que já chegou ao último ambiente da esteira">
+                                Somente em voo
+                            </label>
+                        </div>
+                        <button id="addPrBtn" class="btn btn-primary" title="Novo PR (N)">
+                            <i data-lucide="plus"></i> Novo PR
+                        </button>
+                    </div>
                 </div>
                 <div id="dashboard" class="data-card" style="margin-bottom: 3rem;">
                     <div class="table-container">
@@ -180,6 +192,7 @@
                                     <th>Resumo</th>
                                     <th>Dev</th>
                                     <th>Status</th>
+                                    <th>Esteira</th>
                                     <th>Links</th>
                                     <th style="text-align: center;">Ações</th>
                                 </tr>

--- a/index.html
+++ b/index.html
@@ -15,9 +15,10 @@
 
 <body>
     <!-- Tela de login padrão (usuário/email + senha) -->
-    <div id="profileScreen" class="modal-overlay" style="display: none;">
+    <div id="profileScreen" class="modal-overlay" style="display: none;" role="dialog" aria-modal="true"
+        aria-labelledby="loginTitle">
         <div class="login-card">
-            <h1 class="login-title">PR Manager</h1>
+            <h1 id="loginTitle" class="login-title">PR Manager</h1>
             <p class="login-subtitle">Entre com suas credenciais</p>
             <form id="loginForm" autocomplete="on" novalidate>
                 <div class="form-group login-field">
@@ -44,6 +45,9 @@
                 </p>
                 <button type="submit" id="loginSubmitBtn" class="btn btn-primary login-submit">Entrar</button>
             </form>
+            <button type="button" id="loginCancelBtn" class="btn btn-outline login-cancel" hidden>
+                Voltar ao sistema
+            </button>
         </div>
     </div>
 
@@ -71,7 +75,7 @@
     </div>
 
     <div class="container auth-guarded">
-        <header>
+        <header class="dashboard-header">
             <div class="logo-area">
                 <div style="display: flex; align-items: center; gap: 1rem;">
                     <div id="currentUserDisplay" class="current-user-avatar admin-only" title="Mudar Usuário">--</div>
@@ -161,21 +165,23 @@
 
             <div id="homeView">
                 <!-- PRs Em Aberto -->
-                <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem;">
+                <div class="dashboard-section-head" style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem;">
                     <h3
                         style="color: var(--text-primary); border-left: 4px solid var(--accent-color); padding-left: 10px; margin: 0;">
                         PRs em Aberto <span id="totalOpenPrs" class="tag"
                             style="margin-left: 10px; background: var(--accent-color); color: white; display: none;">0</span>
                     </h3>
                     <div style="display: flex; align-items: center; gap: 1rem;">
-                        <!-- Épico 2: "em voo" é filtro derivado, não estado gravado. Nada é
-                             apagado — desmarcar traz de volta o que já chegou em produção. -->
+                        <!-- Épico 2: filtro derivado, não estado gravado. Nada é apagado —
+                             desmarcar traz de volta o que já foi entregue.
+                             O rótulo evita citar "Produção": o último degrau da esteira é
+                             configurável por app, e um app pode terminar em outro ambiente. -->
                         <div class="form-check form-switch m-0">
                             <input class="form-check-input" type="checkbox" role="switch" id="inFlightToggle" checked>
                             <label class="form-check-label" for="inFlightToggle"
                                 style="color: var(--text-secondary); font-size: 0.85rem; white-space: nowrap;"
-                                title="Esconde o que já chegou ao último ambiente da esteira">
-                                Somente em voo
+                                title="Esconde os PRs cuja versão já chegou ao último ambiente da esteira">
+                                Ainda não entregues
                             </label>
                         </div>
                         <button id="addPrBtn" class="btn btn-primary" title="Novo PR (N)">
@@ -183,6 +189,53 @@
                         </button>
                     </div>
                 </div>
+                <!-- Filtros da esteira (Épico 2, 3.4). Ambiente é populado a partir da esteira
+                     do app selecionado — não é uma lista fixa de dev/stg/prod. -->
+                <details id="filterPanel" class="filter-panel" open>
+                    <summary><i data-lucide="sliders-horizontal" aria-hidden="true"></i> <span id="filterPanelLabel">Filtros</span></summary>
+                <div class="esteira-filters" role="group" aria-label="Filtros da lista de PRs">
+                    <div class="esteira-filters__field">
+                        <label for="filterApp">App</label>
+                        <select id="filterApp" class="form-select form-select-sm">
+                            <option value="">Todos</option>
+                        </select>
+                    </div>
+                    <div class="esteira-filters__field">
+                        <label for="filterStatus">Status</label>
+                        <select id="filterStatus" class="form-select form-select-sm">
+                            <option value="">Todos</option>
+                            <option value="revisao">Em revisão</option>
+                            <option value="ajustes">Em ajustes</option>
+                            <option value="aprovado">Aprovado</option>
+                            <option value="versionado">Com versão</option>
+                        </select>
+                    </div>
+                    <div class="esteira-filters__field">
+                        <label for="filterEnvironment">Ambiente</label>
+                        <select id="filterEnvironment" class="form-select form-select-sm">
+                            <option value="">Todos</option>
+                        </select>
+                    </div>
+                    <div class="esteira-filters__field">
+                        <label for="filterSprint">Sprint</label>
+                        <select id="filterSprint" class="form-select form-select-sm">
+                            <option value="">Todas</option>
+                            <option value="__sem__">Sem sprint</option>
+                        </select>
+                    </div>
+                    <button id="filterClearBtn" class="btn btn-outline btn-sm" type="button">Limpar</button>
+                </div>
+                </details>
+
+                <div id="dashboardLoadError" class="page-state page-state--error" role="alert" hidden>
+                    <i data-lucide="wifi-off" aria-hidden="true"></i>
+                    <div>
+                        <strong>Não foi possível atualizar os dados.</strong>
+                        <span id="dashboardLoadErrorText">Sua sessão foi preservada. Tente novamente.</span>
+                    </div>
+                    <button id="dashboardRetryBtn" class="btn btn-outline btn-sm" type="button">Tentar novamente</button>
+                </div>
+
                 <div id="dashboard" class="data-card" style="margin-bottom: 3rem;">
                     <div class="table-container">
                         <table id="openPrTable">
@@ -213,9 +266,12 @@
                     <!-- Tables will be injected here per project -->
                 </div>
 
+                <!-- Épico 2: o rótulo do ambiente de validação vem da esteira do app; um app
+                     dev → prod não tem staging e não pode anunciar "(STG)". Preenchido por
+                     script.js (atualizarRotuloValidacao). -->
                 <h3
                     style="margin-top: 2rem; margin-bottom: 1rem; color: var(--text-primary); border-left: 4px solid #8e44ad; padding-left: 10px;">
-                    Versões em Teste (STG) <span id="totalTestingPrs" class="tag"
+                    <span id="testingSectionLabel">Versões em validação</span> <span id="totalTestingPrs" class="tag"
                         style="margin-left: 10px; background: #8e44ad; color: white; display: none;">0</span></h3>
                 <div id="dashboardTesting" class="data-card">
                     <!-- Testing tables will be injected here -->
@@ -224,7 +280,7 @@
                 <h3
                     style="margin-top: 2rem; margin-bottom: 1rem; color: var(--text-secondary); border-left: 4px solid #30363d; padding-left: 10px;">
                     Histórico de Sprints</h3>
-                <div id="dashboardHistory" class="data-card" style="opacity: 0.8;">
+                <div id="dashboardHistory" class="data-card">
                     <!-- History tables will be injected here -->
                 </div>
             </div>
@@ -275,7 +331,7 @@
     <div id="requestVersionModal" class="modal-overlay">
         <div class="modal-content" style="max-width: 420px;">
             <div class="modal-header">
-                <h2>Solicitar Versão</h2>
+                <h2>Empacotar PRs</h2>
                 <button class="close-btn">&times;</button>
             </div>
             <div style="display: flex; flex-direction: column; gap: 1rem;">
@@ -290,7 +346,7 @@
                 </div>
                 <div style="display: flex; justify-content: flex-end; gap: 0.75rem;">
                     <button id="cancelRequestVersionModalBtn" class="btn btn-outline close-modal" type="button">Cancelar</button>
-                    <button id="confirmRequestVersionModalBtn" class="btn btn-primary" type="button">Solicitar</button>
+                    <button id="confirmRequestVersionModalBtn" class="btn btn-primary" type="button">Empacotar PRs</button>
                 </div>
             </div>
         </div>
@@ -421,22 +477,6 @@
                         <input type="text" id="summary" placeholder="Ex: Correção do cálculo de imposto" required>
                         <span class="field-error">Informe o resumo do PR.</span>
                     </div>
-                    <div class="form-group">
-                        <label>Link PR</label>
-                        <input type="url" id="prLink" placeholder="https://bitbucket.org/...">
-                        <span class="field-error">Informe uma URL válida para o PR.</span>
-                    </div>
-                    <div class="form-group">
-                        <label>Link Task (Jira)</label>
-                        <input type="url" id="taskLink" placeholder="https://atlassian.net/...">
-                        <span class="field-error">Informe uma URL válida para a task.</span>
-                    </div>
-                    <div class="form-group" style="display: flex; flex-direction: column; gap: 0.5rem;">
-                        <label>Post no Teams</label>
-                        <input type="url" id="teamsLink" placeholder="Link da mensagem">
-                        <span class="field-error">Informe uma URL válida para o post no Teams.</span>
-                    </div>
-
                     <div style="display: flex; align-items: center; gap: 0.6rem; margin-top: 0.3rem;">
                         <div class="form-group" style="display: flex; flex-direction: column; gap: 0.5rem;">
                             <label>Este PR não requer testes de QA</label>
@@ -455,24 +495,34 @@
 
                     </div>
 
-                    <div class="form-group full-width"
-                        style="margin-top: 0.5rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
-                        <div
-                            style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 0.8rem;">
-                            <div style="display: flex; align-items: center;">
-                                <label
-                                    style="margin: 0; font-weight: 600; color: var(--text-primary); font-size: 0.8rem;">Tasks
-                                    Vinculadas (Max 5)</label>
-                                <div id="relatedTaskIdsContainer"
-                                    style="display: none; gap: 0.3rem; align-items: center; margin-left: 10px;"></div>
+                    <div class="form-group full-width" id="prLinksSection">
+                        <span class="pr-links-title">Vínculos</span>
+                        <p style="color: var(--text-secondary); font-size: 0.78rem; margin: 0.25rem 0 0.5rem;">
+                            Nenhum vínculo é obrigatório - hotfix e bugfix entram sem task.
+                        </p>
+                        <ul id="prLinksList" class="link-list"></ul>
+                        <div class="pr-link-form">
+                            <div class="pr-link-form__field">
+                                <label for="prLinkKind">Tipo</label>
+                                <select id="prLinkKind" class="form-select form-select-sm">
+                                    <option value="Task">Task</option>
+                                    <option value="Pr">Pull Request</option>
+                                    <option value="Communication">Comunicação</option>
+                                    <option value="Pipeline">Pipeline</option>
+                                    <option value="Other">Outro</option>
+                                </select>
                             </div>
-                            <button type="button" id="addRelatedTaskBtn" class="btn btn-outline">
-                                <i data-lucide="plus-circle" style="width: 14px;"></i> Nova Task
-                            </button>
+                            <div class="pr-link-form__field pr-link-form__field--url">
+                                <label for="prLinkUrl">Endereço</label>
+                                <input type="url" id="prLinkUrl" class="form-control form-control-sm" placeholder="https://..." aria-describedby="prLinkUrlError">
+                            </div>
+                            <div class="pr-link-form__field">
+                                <label for="prLinkLabel">Rótulo</label>
+                                <input type="text" id="prLinkLabel" class="form-control form-control-sm" placeholder="Opcional" maxlength="200">
+                            </div>
+                            <button type="button" id="prLinkAddBtn" class="btn btn-outline btn-sm">Adicionar</button>
                         </div>
-                        <div id="relatedTasksContainer" style="display: flex; flex-direction: column; gap: 0.5rem;">
-                            <!-- inputs addeddynamically -->
-                        </div>
+                        <div class="field-error" id="prLinkUrlError" aria-live="polite"></div>
                     </div>
                 </div>
                 <div style="margin-top: 2rem; display: flex; justify-content: flex-end; gap: 1rem;">
@@ -480,6 +530,31 @@
                     <button id="prSubmitBtn" type="submit" class="btn btn-primary">Salvar</button>
                 </div>
             </form>
+        </div>
+    </div>
+
+    <!-- Hotfix (Épico 2, D5): a versão passa a poder ir direto ao último ambiente, pulando a
+         guarda de ordem. A justificativa é obrigatória e vai para o histórico — é o que separa
+         um atalho auditado de um furo na esteira. -->
+    <div id="hotfixModal" class="modal-overlay" role="dialog" aria-modal="true"
+        aria-labelledby="hotfixModalTitle" style="z-index: 2200;">
+        <div class="modal-content" style="max-width: 520px;">
+            <div class="modal-header">
+                <h3 id="hotfixModalTitle">Marcar versão como hotfix</h3>
+            </div>
+            <p style="color: var(--text-secondary); font-size: 0.88rem;">
+                A versão poderá ser implantada direto no último ambiente, sem passar pelos
+                degraus anteriores da esteira. Só antes do primeiro deploy.
+            </p>
+            <div class="form-group">
+                <label for="hotfixReason">Justificativa</label>
+                <textarea id="hotfixReason" rows="3" placeholder="O que exige pular a esteira?"></textarea>
+                <div class="field-error" id="hotfixReasonError"></div>
+            </div>
+            <div style="margin-top: 1.5rem; display: flex; justify-content: flex-end; gap: 1rem;">
+                <button type="button" class="btn btn-outline" id="hotfixCancelBtn">Cancelar</button>
+                <button type="button" class="btn btn-primary" id="hotfixConfirmBtn">Marcar como hotfix</button>
+            </div>
         </div>
     </div>
 

--- a/src/apiService.js
+++ b/src/apiService.js
@@ -29,6 +29,33 @@ export async function parseResponseBody(response) {
   return JSON.parse(text);
 }
 
+/**
+ * Lê o corpo de uma resposta de erro sem estourar quando ele vem vazio.
+ *
+ * O ASP.NET responde 403 (Forbid) e 401 com ZERO bytes. Um `await response.json()` direto
+ * lança SyntaxError e o erro real desaparece atrás de "Unexpected end of JSON input" — o
+ * chamador perde o status e mostra uma mensagem que não ajuda ninguém a entender o que houve.
+ */
+async function lerCorpoDeErro(response) {
+  try {
+    return (await parseResponseBody(response)) || {};
+  } catch {
+    return {};
+  }
+}
+
+/** Mensagem legível por status, para quando a API não manda corpo. */
+function descricaoDoStatus(response) {
+  switch (response.status) {
+    case 401: return "Sua sessão expirou. Entre novamente.";
+    case 403: return "Você não tem permissão para esta ação.";
+    // Ids de PR/lote são globais, não por tenant: pedir um recurso de outro tenant cai aqui.
+    case 404: return "Não encontrado neste tenant. Atualize a página e tente de novo.";
+    case 409: return "O estado mudou enquanto você olhava a tela. Atualize e tente de novo.";
+    default: return response.statusText || `Erro ${response.status}`;
+  }
+}
+
 // Helper genérico para os endpoints novos do Épico 9 (Tenants, Convites, Memberships,
 // Notificações) — mesmo padrão de appsRequest/environmentsRequest, sem repetir por recurso.
 async function apiRequest(path, options = {}) {
@@ -38,7 +65,10 @@ async function apiRequest(path, options = {}) {
   });
   if (!response.ok) {
     const body = await parseResponseBody(response).catch(() => ({}));
-    throw new Error(body?.error || `Erro na API: ${response.statusText}`);
+    const error = new Error(body?.error || `Erro na API: ${response.statusText}`);
+    error.status = response.status;
+    error.body = body;
+    throw error;
   }
   return parseResponseBody(response);
 }
@@ -204,9 +234,9 @@ async function requestCorrection(prId) {
     });
 
     if (!response.ok) {
-      const errorBody = await response.json();
+      const errorBody = await lerCorpoDeErro(response);
       throw new Error(
-        `Erro ao solicitar correção: ${errorBody.message || response.statusText}`,
+        `Erro ao solicitar correção: ${errorBody.message || errorBody.error || descricaoDoStatus(response)}`,
       );
     }
 
@@ -237,9 +267,9 @@ async function requestVersionBatch(prIds, requestedVersionDevId, requestedVersio
     });
 
     if (!response.ok) {
-      const errorBody = await response.json();
+      const errorBody = await lerCorpoDeErro(response);
       throw new Error(
-        `Erro ao solicitar versão em lote: ${errorBody.message || response.statusText}`,
+        `Erro ao solicitar versão em lote: ${errorBody.message || errorBody.error || descricaoDoStatus(response)}`,
       );
     }
 
@@ -262,9 +292,9 @@ async function saveVersionBatch(batchData) {
     });
 
     if (!response.ok) {
-      const errorBody = await response.json();
+      const errorBody = await lerCorpoDeErro(response);
       throw new Error(
-        `Erro ao salvar versão em lote: ${errorBody.message || response.statusText}`,
+        `Erro ao salvar versão em lote: ${errorBody.message || errorBody.error || descricaoDoStatus(response)}`,
       );
     }
 
@@ -425,9 +455,9 @@ async function approvePR(prId, approverId) {
     });
 
     if (!response.ok) {
-      const errorBody = await response.json();
+      const errorBody = await lerCorpoDeErro(response);
       throw new Error(
-        `Erro ao aprovar: ${errorBody.message || response.statusText}`,
+        errorBody.message || errorBody.error || descricaoDoStatus(response),
       );
     }
 
@@ -449,9 +479,9 @@ async function fetchPrEvents(prId) {
     });
 
     if (!response.ok) {
-      const errorBody = await response.json();
+      const errorBody = await lerCorpoDeErro(response);
       throw new Error(
-        `Erro ao buscar histórico: ${errorBody.message || response.statusText}`,
+        `Erro ao buscar histórico: ${errorBody.message || errorBody.error || descricaoDoStatus(response)}`,
       );
     }
 
@@ -472,9 +502,9 @@ async function markPrFixed(prId) {
     });
 
     if (!response.ok) {
-      const errorBody = await response.json();
+      const errorBody = await lerCorpoDeErro(response);
       throw new Error(
-        `Erro ao marcar como corrigido: ${errorBody.message || response.statusText}`,
+        `Erro ao marcar como corrigido: ${errorBody.message || errorBody.error || descricaoDoStatus(response)}`,
       );
     }
 
@@ -509,9 +539,9 @@ async function saveAutomationConfig(configData, appId = null) {
     });
 
     if (!response.ok) {
-      const errorBody = await response.json();
+      const errorBody = await lerCorpoDeErro(response);
       throw new Error(
-        `Erro ao salvar config: ${errorBody.message || response.statusText}`,
+        `Erro ao salvar config: ${errorBody.message || errorBody.error || descricaoDoStatus(response)}`,
       );
     }
 
@@ -545,9 +575,9 @@ async function login(username, password) {
       // Resposta de erro nem sempre é JSON (proxy/gateway devolve HTML), então o parse
       // não pode derrubar o tratamento. O status vai junto no erro para a tela distinguir
       // credencial recusada de servidor indisponível.
-      const errorBody = await response.json().catch(() => ({}));
+      const errorBody = await lerCorpoDeErro(response);
       const error = new Error(
-        `Login falhou: ${errorBody.message || response.statusText}`,
+        `Login falhou: ${errorBody.message || errorBody.error || descricaoDoStatus(response)}`,
       );
       error.status = response.status;
       throw error;
@@ -739,9 +769,9 @@ async function archivePR(prId) {
     });
 
     if (!response.ok) {
-      const errorBody = await response.json();
+      const errorBody = await lerCorpoDeErro(response);
       throw new Error(
-        `Erro ao arquivar PR: ${errorBody.message || response.statusText}`,
+        `Erro ao arquivar PR: ${errorBody.message || errorBody.error || descricaoDoStatus(response)}`,
       );
     }
 
@@ -819,9 +849,9 @@ async function createMonitorStatusApp(appData) {
     });
 
     if (!response.ok) {
-      const errorBody = await response.json();
+      const errorBody = await lerCorpoDeErro(response);
       throw new Error(
-        `Erro ao criar aplicação: ${errorBody.message || response.statusText}`,
+        `Erro ao criar aplicação: ${errorBody.message || errorBody.error || descricaoDoStatus(response)}`,
       );
     }
 
@@ -843,9 +873,9 @@ async function updateMonitorStatusApp(appId, appData) {
     });
 
     if (!response.ok) {
-      const errorBody = await response.json();
+      const errorBody = await lerCorpoDeErro(response);
       throw new Error(
-        `Erro ao atualizar aplicação: ${errorBody.message || response.statusText}`,
+        `Erro ao atualizar aplicação: ${errorBody.message || errorBody.error || descricaoDoStatus(response)}`,
       );
     }
 
@@ -866,9 +896,9 @@ async function deleteMonitorStatusApp(appId) {
     });
 
     if (!response.ok) {
-      const errorBody = await response.json().catch(() => ({}));
+      const errorBody = await lerCorpoDeErro(response);
       throw new Error(
-        `Erro ao remover aplicação: ${errorBody.message || response.statusText}`,
+        `Erro ao remover aplicação: ${errorBody.message || errorBody.error || descricaoDoStatus(response)}`,
       );
     }
 
@@ -890,9 +920,9 @@ async function checkMonitorStatusApp(appId) {
     });
 
     if (!response.ok) {
-      const errorBody = await response.json().catch(() => ({}));
+      const errorBody = await lerCorpoDeErro(response);
       throw new Error(
-        `Erro ao verificar aplicação: ${errorBody.message || response.statusText}`,
+        `Erro ao verificar aplicação: ${errorBody.message || errorBody.error || descricaoDoStatus(response)}`,
       );
     }
 
@@ -914,8 +944,8 @@ async function getMonitorStatusAppDetails(appId) {
     });
 
     if (!response.ok) {
-      const errorBody = await response.json().catch(() => ({}));
-      throw new Error(`Erro ao buscar detalhes da aplicação: ${errorBody.message || response.statusText}`);
+      const errorBody = await lerCorpoDeErro(response);
+      throw new Error(`Erro ao buscar detalhes da aplicação: ${errorBody.message || errorBody.error || descricaoDoStatus(response)}`);
     }
 
     return await response.json();

--- a/src/apiService.js
+++ b/src/apiService.js
@@ -73,8 +73,12 @@ const addTenantMember = (tenantId, data) => apiRequest(`/tenants/${tenantId}/mem
 const fetchNotifications = (onlyUnread) => apiRequest(`/Notifications${onlyUnread ? "?onlyUnread=true" : ""}`);
 const markNotificationRead = (id) => apiRequest(`/Notifications/${id}/read`, { method: "PUT" });
 
-async function fetchPRs() {
-  const url = `${ApiConstants.BASE_URL}/PullRequests`;
+/**
+ * Épico 2 (D6): a API filtra "em voo" por padrão — integrado e ainda não entregue.
+ * Nada é apagado; `inFlight = false` traz também o que já chegou ao último ambiente.
+ */
+async function fetchPRs(inFlight = true) {
+  const url = `${ApiConstants.BASE_URL}/PullRequests?inFlight=${inFlight ? "true" : "false"}`;
 
   try {
     const response = await fetch(url, {
@@ -598,9 +602,11 @@ const createOrganization = (data) => organizationsRequest("", { method: "POST", 
 const updateOrganization = (id, data) => organizationsRequest(`/${id}`, { method: "PUT", body: JSON.stringify(data) });
 const deactivateOrganization = (id) => organizationsRequest(`/${id}`, { method: "PUT", body: JSON.stringify({ isActive: false }) });
 
-// ── Ambientes (Épico 6) ─────────────────────────────────────────────────────
-// O erro carrega status e body: o chamador diferencia 403 (sem papel), 409
-// (stg_active_batch_changed / not_active) e 501 (dev sem fluxo nesta fase).
+// ── Ambientes e esteira (Épico 6 + Épico 2) ─────────────────────────────────
+// O erro carrega status e body: o chamador diferencia 403 (sem papel) e 409
+// (previous_env_batch_changed / not_active / environment_has_deployments).
+// O 501 de dev saiu: a esteira é configurável e o ambiente de integração recebe
+// PR avulso por presença, não deploy de versão.
 
 async function environmentsRequest(appId, path, options = {}) {
   const response = await fetch(`${ApiConstants.BASE_URL}/Apps/${appId}/Environments${path}`, {
@@ -624,6 +630,64 @@ const deployToEnvironment = (appId, kind, batchId) =>
   environmentsRequest(appId, `/${kind}/deploy`, { method: "POST", body: JSON.stringify({ batchId }) });
 const rollbackDeployment = (appId, kind, deploymentId) =>
   environmentsRequest(appId, `/${kind}/deployments/${deploymentId}/rollback`, { method: "POST" });
+
+// Esteira configurável (Épico 2): substitui a configuração inteira, não faz merge parcial.
+const updatePipeline = (appId, steps) =>
+  environmentsRequest(appId, "/pipeline", { method: "PUT", body: JSON.stringify({ steps }) });
+const removeEnvironment = (appId, kind) =>
+  environmentsRequest(appId, `/${kind}`, { method: "DELETE" });
+
+// ── Presença do PR e vínculos (Épico 2) ─────────────────────────────────────
+
+async function appPrRequest(appId, path, options = {}) {
+  const response = await fetch(`${ApiConstants.BASE_URL}/Apps/${appId}/PullRequests${path}`, {
+    headers: getBackendHeaders(),
+    cache: "no-store",
+    ...options,
+  });
+  if (!response.ok) {
+    const body = await response.json().catch(() => ({}));
+    const error = new Error(body.error || `Erro na API de PRs: ${response.statusText}`);
+    error.status = response.status;
+    error.body = body;
+    throw error;
+  }
+  return response.status === 204 ? null : await response.json();
+}
+
+/** Registra que o PR entrou na branch de integração. Só Gestor/Admin. */
+const registerPrPresence = (appId, prId, kind) =>
+  appPrRequest(appId, `/${prId}/presence/${kind}`, { method: "POST" });
+
+/** Revert: o código saiu da branch. Motivo obrigatório. */
+const revertPrPresence = (appId, prId, kind, reason) =>
+  appPrRequest(appId, `/${prId}/presence/${kind}`, {
+    method: "DELETE",
+    body: JSON.stringify({ reason }),
+  });
+
+const fetchPrLinks = (appId, prId) => appPrRequest(appId, `/${prId}/links`);
+const addPrLink = (appId, prId, link) =>
+  appPrRequest(appId, `/${prId}/links`, { method: "POST", body: JSON.stringify(link) });
+const removePrLink = (appId, prId, linkId) =>
+  appPrRequest(appId, `/${prId}/links/${linkId}`, { method: "DELETE" });
+
+/** Marca a versão como hotfix: passa a poder pular a guarda de ordem da esteira. */
+async function markBatchAsHotfix(batchId, reason) {
+  const response = await fetch(`${ApiConstants.BASE_URL}/VersionBatches/${batchId}/mark-hotfix`, {
+    method: "POST",
+    headers: getBackendHeaders(),
+    body: JSON.stringify({ reason }),
+  });
+  if (!response.ok) {
+    const body = await response.json().catch(() => ({}));
+    const error = new Error(body.error || `Erro ao marcar hotfix: ${response.statusText}`);
+    error.status = response.status;
+    error.body = body;
+    throw error;
+  }
+  return await response.json();
+}
 
 // ── Gestão de usuários (Épico 2 — Admin) ────────────────────────────────────
 
@@ -900,6 +964,14 @@ export {
   fetchEnvironmentHistory,
   deployToEnvironment,
   rollbackDeployment,
+  updatePipeline,
+  removeEnvironment,
+  registerPrPresence,
+  revertPrPresence,
+  fetchPrLinks,
+  addPrLink,
+  removePrLink,
+  markBatchAsHotfix,
   createUser,
   updateUser,
   deactivateUser,

--- a/src/appsHome.js
+++ b/src/appsHome.js
@@ -63,7 +63,10 @@ async function renderApps() {
                 <button class="btn btn-primary app-enter-btn" data-name="${app.name}">Entrar</button>
                 ${app.repositoryUrl ? `<a class="btn btn-outline" href="${app.repositoryUrl}" target="_blank" rel="noopener" title="Repositório"><i data-lucide="git-branch"></i></a>` : ''}
                 <button class="btn btn-outline app-members-btn" data-id="${app.id}" title="Membros"><i data-lucide="users"></i></button>
-                <button class="btn btn-outline app-envs-btn" data-id="${app.id}" title="Ambientes"><i data-lucide="server"></i></button>
+                <button class="btn btn-outline app-envs-btn" data-id="${app.id}" title="Configurar ambientes e esteira">
+                    <i data-lucide="server" aria-hidden="true"></i>
+                    Ambientes e esteira
+                </button>
                 ${isAdmin ? `
                     <button class="btn btn-outline app-edit-btn" data-id="${app.id}" title="Editar"><i data-lucide="pencil"></i></button>
                     <button class="btn btn-outline app-deactivate-btn" data-id="${app.id}" title="Desativar"><i data-lucide="archive"></i></button>` : ''}

--- a/src/authService.js
+++ b/src/authService.js
@@ -92,6 +92,7 @@ export function getMembershipsFromToken() {
 // fresca é GET /api/Users/me, revalidada no backend a cada chamada — cacheada aqui em memória
 // e atualizada por refreshMe(), chamada no login e na troca de tenant.
 let meCache = null;
+let meUnavailable = false;
 
 /**
  * Busca a identidade "fresca" do usuário logado (IsPlatformAdmin, tenant atual, papel no
@@ -102,6 +103,7 @@ let meCache = null;
 export async function refreshMe() {
     try {
         const me = await API.fetchMe();
+        meUnavailable = false;
         meCache = me;
         if (me?.name) setItem('appUser', me.name);
         if (me?.id) setItem('appUserId', me.id);
@@ -118,6 +120,7 @@ export async function refreshMe() {
     } catch (error) {
         console.error('Falha ao buscar identidade atual (/Users/me):', error);
         meCache = null;
+        meUnavailable = error?.status !== 401 && error?.status !== 403;
         return null;
     }
 }
@@ -132,6 +135,7 @@ export async function restoreSession() {
 
     let me = await refreshMe();
     if (!me) {
+        if (meUnavailable) return { state: 'unavailable', me: null };
         clearSession();
         return { state: 'unauthenticated', me: null };
     }

--- a/src/domService.js
+++ b/src/domService.js
@@ -14,6 +14,50 @@ function escapeHtml(value) {
     return div.innerHTML;
 }
 
+// Formata a data no padrão do projeto, sem trazer dependência nova.
+function formatShortDate(value) {
+    if (!value) return '';
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? '' : date.toLocaleDateString('pt-BR');
+}
+
+/**
+ * Matriz de ambientes do PR (Épico 2, 2.3). As colunas saem da esteira do app — não são
+ * fixas em três: um cliente pode ter dev+prod ou stg+prod.
+ *
+ * Ambiente de integração mostra presença ("desde quando"), porque ali não existe versão.
+ * Ambiente versionado mostra o número da versão. A assimetria é proposital: é o que
+ * diferencia "o código está mergeado" de "esta versão está implantada".
+ */
+function renderPipelineMatrix(pr) {
+    const steps = Array.isArray(pr.environments) ? pr.environments : [];
+    if (steps.length === 0) {
+        return '<span class="pipeline-empty">Sem esteira configurada</span>';
+    }
+
+    const cells = steps.map((step) => {
+        const kind = String(step.kind || '').toLowerCase();
+        const sinceLabel = formatShortDate(step.since);
+
+        if (!step.present) {
+            return `<span class="pipeline-step pipeline-step--absent" title="${escapeHtml(step.kind)}: não presente">${escapeHtml(step.kind)}</span>`;
+        }
+
+        const detalhe = step.mode === 'Individual'
+            ? (sinceLabel ? `desde ${sinceLabel}` : 'presente')
+            : (step.version || 'sem versão');
+
+        const title = step.mode === 'Individual'
+            ? `${step.kind}: integrado${sinceLabel ? ` desde ${sinceLabel}` : ''}`
+            : `${step.kind}: versão ${step.version || '—'}${sinceLabel ? ` desde ${sinceLabel}` : ''}`;
+
+        return `<span class="pipeline-step pipeline-step--${escapeHtml(kind)}" title="${escapeHtml(title)}">${escapeHtml(step.kind)} <span style="font-weight:500;">${escapeHtml(detalhe)}</span></span>`;
+    });
+
+    // A seta carrega a sequência da esteira; é decoração para quem lê a tela por áudio.
+    return `<div class="pipeline-matrix">${cells.join('<span class="pipeline-arrow" aria-hidden="true">›</span>')}</div>`;
+}
+
 const getProfileImage = (userName) => {
     const profileImages = {
         'Itallo Cerqueira': 'src/assets/profiles/itallo-cerqueira.png',
@@ -308,7 +352,7 @@ function renderOpenTable(data, containerId, onEdit, animate = true) {
     if (!body) return;
     body.innerHTML = '';
     if (data.length === 0) {
-        body.innerHTML = '<tr><td colspan="6" style="text-align: center; padding: 2rem; color: var(--text-secondary);">Nenhum PR pendente.</td></tr>';
+        body.innerHTML = '<tr><td colspan="7" style="text-align: center; padding: 2rem; color: var(--text-secondary);">Nenhum PR pendente.</td></tr>';
         return;
     }
     const grouped = data.reduce((acc, pr) => {
@@ -329,7 +373,7 @@ function renderOpenTable(data, containerId, onEdit, animate = true) {
         if(animate) headerRow.style.animationDelay = `${animationDelay}ms`;
         if(animate) animationDelay += 50;
 
-        headerRow.innerHTML = `<td colspan="6"><div style="display:flex; justify-content:space-between; align-items:center;"><div style="font-weight: 600;">${headerContent}</div></div></td>`;
+        headerRow.innerHTML = `<td colspan="7"><div style="display:flex; justify-content:space-between; align-items:center;"><div style="font-weight: 600;">${headerContent}</div></div></td>`;
         body.appendChild(headerRow);
         
         projectPrs.forEach((pr) => {
@@ -389,6 +433,7 @@ function renderOpenTable(data, containerId, onEdit, animate = true) {
                         ${pr.noTestingRequired ? '<span class="tag" style="background:#8250df; color:white; font-size:0.7rem; padding:0.2rem 0.5rem;" title="Não requer testes de QA">Sem Teste</span>' : ''}
                     </div>
                 </td>
+                <td>${renderPipelineMatrix(pr)}</td>
                 <td><div style="display: flex; gap: 0.8rem;">${pr.teamsLink ? `<a href="${pr.teamsLink}" target="_blank" ${getLinkAttrs('teams-' + pr.id, 'link-icon')} title="Link Teams"><i data-lucide="message-circle" style="width: 16px;"></i></a>` : ''}${pr.taskLink ? `<a href="${pr.taskLink}" target="_blank" ${getLinkAttrs('task-' + pr.id, 'link-icon')} title="Link Task"><i data-lucide="external-link" style="width: 16px;"></i></a>` : ''}${pr.prLink ? `<a href="${pr.prLink}" target="_blank" ${getLinkAttrs('pr-' + pr.id, 'link-icon')} title="Link PR"><i data-lucide="git-pull-request" style="width: 16px;"></i></a>` : ''}${renderRelatedLinks(pr.linksRelatedTask)}</div></td>
                 <td>
                     <div style="display: flex; gap: 5px; justify-content: flex-end;">
@@ -422,6 +467,11 @@ function renderOpenTable(data, containerId, onEdit, animate = true) {
                             onclick="window.togglePrHistory('${pr.id}')">
                             <i data-lucide="history" style="width: 14px;"></i>
                         </button>
+
+                        <a class="btn btn-outline" style="padding: 0.4rem;" title="Ver entrega"
+                            href="entrega.html?appId=${encodeURIComponent(pr.appId)}&prId=${encodeURIComponent(pr.id)}">
+                            <i data-lucide="git-branch" style="width: 14px;"></i>
+                        </a>
 
                         <button class="btn btn-outline" data-roles="Admin"
                             style="padding: 0.4rem; border-color: #da3633; color: #da3633;"

--- a/src/domService.js
+++ b/src/domService.js
@@ -97,12 +97,58 @@ const getLinkAttrs = (uniqueId, extraClass = '') => {
     return ` onclick="window.trackLinkClick(this, '${uniqueId}')" class="${extraClass}${isLast ? ' visited-link' : ''}" `;
 };
 
+const LINK_ICONS = {
+    Task: 'clipboard-list',
+    Pr: 'git-pull-request',
+    Communication: 'message-circle',
+    Pipeline: 'workflow',
+    Other: 'link',
+};
+
+function getPrLinks(pr) {
+    if (Array.isArray(pr.links) && pr.links.length > 0) return pr.links;
+
+    // Compatibilidade somente de leitura durante a migração dos três campos antigos.
+    return [
+        pr.taskLink && { id: `task-${pr.id}`, kind: 'Task', url: pr.taskLink, label: 'Task' },
+        pr.prLink && { id: `pr-${pr.id}`, kind: 'Pr', url: pr.prLink, label: 'Pull Request' },
+        pr.teamsLink && { id: `teams-${pr.id}`, kind: 'Communication', url: pr.teamsLink, label: 'Comunicação' },
+    ].filter(Boolean);
+}
+
+function hasGenericLinks(pr) {
+    return Array.isArray(pr.links) && pr.links.length > 0;
+}
+
+function hasLegacyRelatedTasks(pr) {
+    return !hasGenericLinks(pr)
+        && pr.linksRelatedTask
+        && pr.linksRelatedTask.split(';').some(link => link.trim() !== '');
+}
+
+function renderLegacyRelatedLinks(pr) {
+    return hasGenericLinks(pr) ? '' : renderRelatedLinks(pr.linksRelatedTask);
+}
+
+function renderLinksCell(pr) {
+    const links = getPrLinks(pr).filter(link => /^https?:\/\//i.test(link.url || ''));
+    const rendered = links.map(link => {
+        const icon = LINK_ICONS[link.kind] || LINK_ICONS.Other;
+        const label = link.label || link.kind || 'Vínculo';
+        const uniqueId = `link-${link.id || `${pr.id}-${link.kind}`}`;
+        return `<a href="${escapeHtml(link.url)}" target="_blank" rel="noopener noreferrer" ${getLinkAttrs(uniqueId, 'link-icon')} title="${escapeHtml(label)}" aria-label="Abrir ${escapeHtml(label)}"><i data-lucide="${icon}" style="width: 16px;"></i></a>`;
+    }).join('');
+
+    return rendered || '<span class="pipeline-empty">Sem vínculos</span>';
+}
+
 function renderTaskIdCell(pr, { includeExpand = false } = {}) {
-    const hasRelated = pr.linksRelatedTask && pr.linksRelatedTask.split(';').filter(l => l.trim() !== '').length > 0;
+    const hasRelated = hasLegacyRelatedTasks(pr);
     const expandBtn = includeExpand && hasRelated
         ? `<button class="expand-btn" onclick="window.toggleRelated('${pr.id}', this)"><i data-lucide="chevron-right" style="width: 14px;"></i></button>`
         : '';
-    const mainJiraId = extractJiraId(pr.taskLink) || pr.project || '-';
+    const taskLink = getPrLinks(pr).find(link => link.kind === 'Task')?.url || pr.taskLink;
+    const mainJiraId = extractJiraId(taskLink) || pr.project || '-';
 
     return `
         <td>
@@ -416,7 +462,7 @@ function renderOpenTable(data, containerId, onEdit, animate = true) {
             }
 
 
-            const hasRelated = pr.linksRelatedTask && pr.linksRelatedTask.split(';').filter(l => l.trim() !== '').length > 0;
+            const hasRelated = hasLegacyRelatedTasks(pr);
 
             tr.innerHTML = `
                 ${renderTaskIdCell(pr, { includeExpand: true })}
@@ -434,7 +480,7 @@ function renderOpenTable(data, containerId, onEdit, animate = true) {
                     </div>
                 </td>
                 <td>${renderPipelineMatrix(pr)}</td>
-                <td><div style="display: flex; gap: 0.8rem;">${pr.teamsLink ? `<a href="${pr.teamsLink}" target="_blank" ${getLinkAttrs('teams-' + pr.id, 'link-icon')} title="Link Teams"><i data-lucide="message-circle" style="width: 16px;"></i></a>` : ''}${pr.taskLink ? `<a href="${pr.taskLink}" target="_blank" ${getLinkAttrs('task-' + pr.id, 'link-icon')} title="Link Task"><i data-lucide="external-link" style="width: 16px;"></i></a>` : ''}${pr.prLink ? `<a href="${pr.prLink}" target="_blank" ${getLinkAttrs('pr-' + pr.id, 'link-icon')} title="Link PR"><i data-lucide="git-pull-request" style="width: 16px;"></i></a>` : ''}${renderRelatedLinks(pr.linksRelatedTask)}</div></td>
+                <td><div style="display: flex; gap: 0.8rem; align-items: center;">${renderLinksCell(pr)}${renderLegacyRelatedLinks(pr)}</div></td>
                 <td>
                     <div style="display: flex; gap: 5px; justify-content: flex-end;">
                         <button class="btn btn-outline edit-btn" style="padding: 0.4rem;" title="Editar"><i data-lucide="edit-3" style="width: 14px;"></i></button>
@@ -490,7 +536,7 @@ function renderOpenTable(data, containerId, onEdit, animate = true) {
                 subRow.id = `related-${pr.id}`;
                 subRow.className = 'related-tasks-row';
                 subRow.style.display = 'none';
-                subRow.innerHTML = `<td colspan="6">${renderRelatedTasksList(pr.linksRelatedTask, pr.project)}</td>`;
+                subRow.innerHTML = `<td colspan="7">${renderRelatedTasksList(pr.linksRelatedTask, pr.project)}</td>`;
                 body.appendChild(subRow);
             }
 
@@ -499,7 +545,7 @@ function renderOpenTable(data, containerId, onEdit, animate = true) {
             historyRow.id = `history-${pr.id}`;
             historyRow.className = 'pr-history-row';
             historyRow.style.display = 'none';
-            historyRow.innerHTML = `<td colspan="6"></td>`;
+            historyRow.innerHTML = `<td colspan="7"></td>`;
             body.appendChild(historyRow);
         });
     });
@@ -560,7 +606,10 @@ function renderTestingTable(activeSprints, containerId, onEdit, animate = true) 
     let hasDeployed = false;
     let totalTestingBatches = 0;
     activeSprints.forEach(sprint => {
-        const deployedBatches = (sprint.versionBatches || []).filter(b => b.status === 'Deployed');
+        // script.js já entrega somente lotes cujo batch está ativo no ambiente real de
+        // validação. O status legado "Deployed" era específico de STG e não é atualizado
+        // pelo endpoint genérico de deploy.
+        const deployedBatches = sprint.versionBatches || [];
         if (deployedBatches.length > 0) hasDeployed = true;
         totalTestingBatches += deployedBatches.length;
     });
@@ -572,7 +621,7 @@ function renderTestingTable(activeSprints, containerId, onEdit, animate = true) 
     }
 
     if (!hasDeployed) {
-        container.innerHTML = '<div style="text-align: center; padding: 2rem; color: var(--text-secondary); background: #161b22; border: 1px solid #30363d; border-radius: 6px;">Nenhuma versão em teste (STG).</div>';
+        container.innerHTML = '<div class="empty-state">Nenhuma versão em validação.</div>';
         return;
     }
 
@@ -581,7 +630,7 @@ function renderTestingTable(activeSprints, containerId, onEdit, animate = true) 
     let animationDelay = 0;
 
     activeSprints.forEach(sprint => {
-        const deployedBatches = (sprint.versionBatches || []).filter(b => b.status === 'Deployed');
+        const deployedBatches = sprint.versionBatches || [];
         
         if (deployedBatches.length === 0) return;
 
@@ -623,7 +672,7 @@ function renderTestingTable(activeSprints, containerId, onEdit, animate = true) 
         sprintTitle.textContent = sprint.name;
         sprintTitle.style.cssText = `color: var(--text-primary); margin: 0; padding-left: 15px; border-left: 4px solid ${testingTheme.accent}; font-size: 1.1rem; opacity: 0.9;`;
         
-        const completeBtn = `
+        const completeBtn = sprint.canComplete === false ? '' : `
             <button class="btn btn-outline" data-roles="Admin,QA" style="font-size: 0.75rem; padding: 0.3rem 0.8rem; border-color: ${testingTheme.actionBorder}; background: ${testingTheme.actionBackground}; color: ${testingTheme.actionText};" onclick="window.completeSprint(${sprint.id})">
                 <i data-lucide="check-circle-2" style="width: 14px; margin-right: 5px;"></i>
                 Concluir Sprint
@@ -699,7 +748,7 @@ function renderTestingTable(activeSprints, containerId, onEdit, animate = true) 
                     </button>
                 `;
 
-                tr.innerHTML = `${renderTaskIdCell(pr).replace('<td>', '<td style="width: 0px; white-space: nowrap;">')}<td>${pr.summary || '-'}${pr.noTestingRequired ? ' <span class="tag" style="background:#8250df; color:white; font-size:0.7rem; padding:0.2rem 0.5rem; margin-left:5px;" title="Nao requer testes de QA">Sem Teste</span>' : ''}</td><td><div style="display: flex; align-items: center; gap: 8px;"><img src="${getDemoImage(pr.dev)}" style="width: 34px; height: 34px; object-fit: cover; border-radius: 50%;" title="${getDemoName(pr.dev)}">${getDemoName(pr.dev) || '-'}</div></td><td><div style="display: flex; gap: 0.8rem; align-items: center; justify-content: end;">${pr.teamsLink ? `<a href="${pr.teamsLink}" target="_blank" ${getLinkAttrs('teams-' + pr.id, 'link-icon')} title="Link Teams"><i data-lucide="message-circle" style="width: 16px;"></i></a>` : ''}${pr.taskLink ? `<a href="${pr.taskLink}" target="_blank" ${getLinkAttrs('task-' + pr.id, 'link-icon')} title="Link Task"><i data-lucide="external-link" style="width: 14px;"></i></a>` : ''}${pr.prLink ? `<a href="${pr.prLink}" target="_blank" ${getLinkAttrs('pr-' + pr.id, 'link-icon')} title="Link PR"><i data-lucide="git-pull-request" style="width: 14px;"></i></a>` : ''}${renderRelatedLinks(pr.linksRelatedTask)}${prRemoveBtn}</div></td>`;
+                tr.innerHTML = `${renderTaskIdCell(pr).replace('<td>', '<td style="width: 0px; white-space: nowrap;">')}<td>${pr.summary || '-'}${pr.noTestingRequired ? ' <span class="tag" style="background:#8250df; color:white; font-size:0.7rem; padding:0.2rem 0.5rem; margin-left:5px;" title="Nao requer testes de QA">Sem Teste</span>' : ''}</td><td><div style="display: flex; align-items: center; gap: 8px;"><img src="${getDemoImage(pr.dev)}" style="width: 34px; height: 34px; object-fit: cover; border-radius: 50%;" title="${getDemoName(pr.dev)}">${getDemoName(pr.dev) || '-'}</div></td><td><div style="display: flex; gap: 0.8rem; align-items: center; justify-content: end;">${renderLinksCell(pr)}${renderLegacyRelatedLinks(pr)}${prRemoveBtn}</div></td>`;
                 tbody.appendChild(tr);
             });
 
@@ -718,7 +767,7 @@ function renderHistoryTable(inactiveSprints, containerId, onEdit, animate = true
     container.innerHTML = '';
     
     if (inactiveSprints.length === 0) {
-        container.innerHTML = '<div style="text-align: center; padding: 2rem; color: var(--text-secondary); background: #161b22; border: 1px solid #30363d; border-radius: 6px; opacity: 0.6;">Nenhum histórico disponível.</div>';
+        container.innerHTML = '<div class="empty-state">Nenhum histórico disponível.</div>';
         return;
     }
 
@@ -778,7 +827,7 @@ function renderHistoryTable(inactiveSprints, containerId, onEdit, animate = true
             const tbody = table.querySelector('tbody');
             (batch.pullRequests || []).forEach(pr => {
                 const tr = document.createElement('tr');
-                tr.innerHTML = `${renderTaskIdCell(pr)}<td style="padding:0.5rem; color:var(--text-secondary);">${pr.summary || '-'}${pr.noTestingRequired ? ' <span class="tag" style="background:#8250df; color:white; font-size:0.7rem; padding:0.2rem 0.5rem; margin-left:5px;" title="Nao requer testes de QA">Sem Teste</span>' : ''}</td><td style="padding:0.5rem; color:var(--text-secondary);"><div style="display: flex; align-items: center; gap: 8px;"><img src="${getDemoImage(pr.dev)}" style="width: 34px; height: 34px; object-fit: cover; border-radius: 50%;" title="${getDemoName(pr.dev)}">${getDemoName(pr.dev) || '-'}</div></td><td style="padding:0.5rem;"><div style="display: flex; gap: 0.8rem; align-items: center; justify-content: end;">${pr.teamsLink ? `<a href="${pr.teamsLink}" target="_blank" ${getLinkAttrs('teams-' + pr.id, 'link-icon')} title="Link Teams"><i data-lucide="message-circle" style="width: 16px;"></i></a>` : ''}${pr.taskLink ? `<a href="${pr.taskLink}" target="_blank" ${getLinkAttrs('task-' + pr.id, 'link-icon')} title="Link Task"><i data-lucide="external-link" style="width: 14px;"></i></a>` : ''}${pr.prLink ? `<a href="${pr.prLink}" target="_blank" ${getLinkAttrs('pr-' + pr.id, 'link-icon')} title="Link PR"><i data-lucide="git-pull-request" style="width: 14px;"></i></a>` : ''}${renderRelatedLinks(pr.linksRelatedTask)}</div></td>`;
+                tr.innerHTML = `${renderTaskIdCell(pr)}<td style="padding:0.5rem; color:var(--text-secondary);">${pr.summary || '-'}${pr.noTestingRequired ? ' <span class="tag" style="background:#8250df; color:white; font-size:0.7rem; padding:0.2rem 0.5rem; margin-left:5px;" title="Nao requer testes de QA">Sem Teste</span>' : ''}</td><td style="padding:0.5rem; color:var(--text-secondary);"><div style="display: flex; align-items: center; gap: 8px;"><img src="${getDemoImage(pr.dev)}" style="width: 34px; height: 34px; object-fit: cover; border-radius: 50%;" title="${getDemoName(pr.dev)}">${getDemoName(pr.dev) || '-'}</div></td><td style="padding:0.5rem;"><div style="display: flex; gap: 0.8rem; align-items: center; justify-content: end;">${renderLinksCell(pr)}${renderLegacyRelatedLinks(pr)}</div></td>`;
                 tbody.appendChild(tr);
             });
 
@@ -795,7 +844,11 @@ function renderApprovedTables(approvedPrs, batches, containerId, onEdit, animate
     if (!container) return;
     container.innerHTML = '';
 
-    const pendingBatches = batches.filter(b => b.status === 'Pending' || b.status === 'Released');
+    // Cinto e suspensório do lado da tela: lote sem PR não é lote, é casca. O backend passou a
+    // dissolvê-las no cancelamento, mas as que já existem no banco continuariam virando card
+    // morto — com "Empacotar PRs" sem app, "Cancelar" e lixeira que não levam a lugar nenhum.
+    const pendingBatches = batches.filter(b =>
+        (b.status === 'Pending' || b.status === 'Released') && (b.pullRequests?.length ?? 0) > 0);
     
     const prIdsInBatches = new Set(batches.flatMap(b => b.pullRequests.map(pr => pr.id)));
     const backlogPrs = approvedPrs.filter(pr => !prIdsInBatches.has(pr.id));
@@ -823,7 +876,8 @@ function renderApprovedTables(approvedPrs, batches, containerId, onEdit, animate
             currentUser,
             batch.batchId,
             batch.gitlabIssueLink,
-            batch.requestedVersionDevName
+            batch.requestedVersionDevName,
+            batch
         );
         if(animate) card.classList.add('fade-in-row');
         if(animate) card.style.animationDelay = `${animationDelay}ms`;
@@ -833,7 +887,7 @@ function renderApprovedTables(approvedPrs, batches, containerId, onEdit, animate
 
     Object.keys(backlogByProject).sort().forEach(projectName => {
         const projectPrs = backlogByProject[projectName];
-        const card = createApprovedCard(projectName, projectPrs, currentUser, null, null, null);
+        const card = createApprovedCard(projectName, projectPrs, currentUser, null, null, null, null);
         if(animate) card.classList.add('fade-in-row');
         if(animate) card.style.animationDelay = `${animationDelay}ms`;
         if(animate) animationDelay += 50;
@@ -841,11 +895,11 @@ function renderApprovedTables(approvedPrs, batches, containerId, onEdit, animate
     });
 
     if (pendingBatches.length === 0 && backlogPrs.length === 0) {
-        container.innerHTML = '<div style="text-align: center; padding: 2rem; color: var(--text-secondary); background: #161b22; border: 1px solid #30363d; border-radius: 6px;">Nenhum PR aguardando liberação.</div>';
+        container.innerHTML = '<div class="empty-state">Aprove PRs para iniciar um corte de versão.</div>';
     }
 }
 
-function createApprovedCard(projectName, projectPrs, currentUser, batchId, batchLink = null, requestedVersionDevName = null) {
+function createApprovedCard(projectName, projectPrs, currentUser, batchId, batchLink = null, requestedVersionDevName = null, batchContext = null) {
     const isRequestingVersion = projectPrs.some(p => p.versionRequested);
     let headerStyle = '';
     let leftContent = `${projectName} (${projectPrs.length})`;
@@ -858,6 +912,7 @@ function createApprovedCard(projectName, projectPrs, currentUser, batchId, batch
     let deployBtn = '';
     const info = projectPrs.find(p => p.version) || projectPrs[0];
     const gitlabIssueLink = batchLink || info?.gitlabIssueLink;
+    const target = batchContext?.deploymentTarget;
 
     if (hasVersionInfo) {
         let gitlabLink = '';
@@ -869,15 +924,22 @@ function createApprovedCard(projectName, projectPrs, currentUser, batchId, batch
                 </a>
             `;
             
-            deployBtn = `
-                <button class="btn" data-roles="Admin,QA" style="background-color: #8e44ad; color: white; height: 32px; padding: 0 0.6rem; font-size: 0.75rem; margin-left: 10px; display: inline-flex; align-items: center; gap: 5px; border-radius: 4px; line-height: 1;" onclick="window.confirmDeploy('${batchId}')">
-                    <i data-lucide="rocket" style="width: 14px;"></i>
-                    Liberar STG
-                </button>
-            `;
         }
+
+        const deployAction = target && batchId
+            ? `<button class="btn btn-primary" data-roles="Admin" type="button" onclick="window.confirmDeploy(${batchContext.id}, '${batchContext.appId}', '${escapeHtml(target.kind)}', '${escapeHtml(target.label)}')">
+                    <i data-lucide="rocket" style="width: 14px;"></i>
+                    Deploy ${escapeHtml(target.label)}
+               </button>`
+            : '';
+        const hotfixAction = batchId && !batchContext?.isHotfix && !batchContext?.isFrozen
+            ? `<button class="btn btn-outline" data-roles="Admin" type="button" title="Pular a ordem da esteira com justificativa registrada" onclick="window.markBatchHotfix('${batchId}')">
+                    <i data-lucide="zap" style="width: 14px;"></i> Hotfix
+               </button>`
+            : (batchContext?.isHotfix ? '<span class="tag">Hotfix</span>' : '');
+        deployBtn = `${deployAction}${hotfixAction}`;
         rightContent += ` 
-            <div style="display: flex; align-items: center; gap: 15px;">
+            <div class="batch-actions">
                 <span class="tag" style="background:#238636; color:white;">v${info.version}</span>
                 ${gitlabLink}
                 ${deployBtn}
@@ -914,10 +976,14 @@ function createApprovedCard(projectName, projectPrs, currentUser, batchId, batch
     let requestVersionBtn = '';
     
     if (!hasVersionInfo && !isRequestingVersion) {
+            // Passa o APP, não a lista de ids. Antes os ids do corte iam congelados aqui, no
+            // momento do render: qualquer PR aprovado depois disso ficava de fora do lote em
+            // silêncio. Quem clica resolve a lista na hora (window.requestVersionBatch).
+            const appIdDoCard = projectPrs[0]?.appId || '';
             requestVersionBtn = `
-           <button class="btn btn-primary" data-roles="Admin,QA" style="padding: 0.3rem 0.8rem; font-size: 0.75rem; display: flex; align-items: center; gap: 5px; margin-left:15px;" onclick="window.requestVersionBatch([${projectPrs.map(p => p.id).join(',')}], '${projectName.replace(/'/g, "\\'")}')">
+           <button class="btn btn-primary" data-roles="Admin" style="padding: 0.3rem 0.8rem; font-size: 0.75rem; display: flex; align-items: center; gap: 5px; margin-left:15px;" onclick="window.requestVersionBatch('${appIdDoCard}', '${projectName.replace(/'/g, "\\'")}')">
                 <i data-lucide="package-check" style="width: 14px;"></i>
-                Solicitar Versão
+                Empacotar PRs
             </button>`;
     }
     
@@ -974,7 +1040,10 @@ function createApprovedCard(projectName, projectPrs, currentUser, batchId, batch
     const tableContainer = document.createElement('div');
     tableContainer.className = 'table-container';
     const table = document.createElement('table');
-    table.innerHTML = `<thead><tr><th>Task</th><th>Resumo</th><th>Dev</th><th>Status</th><th>Rollback</th><th>Links</th></tr></thead><tbody></tbody>`;
+    // A coluna Esteira também aqui: um PR aprovado é justamente o que está andando pelos
+    // ambientes. Ela existir só na lista de pendentes fazia a matriz sumir no momento em que
+    // ela passa a importar.
+    table.innerHTML = `<thead><tr><th>Task</th><th>Resumo</th><th>Dev</th><th>Status</th><th>Esteira</th><th>Rollback</th><th>Links</th></tr></thead><tbody></tbody>`;
     const tbody = table.querySelector('tbody');
     
     projectPrs.forEach(pr => {
@@ -1001,7 +1070,7 @@ function createApprovedCard(projectName, projectPrs, currentUser, batchId, batch
         }
 
         const tr = document.createElement('tr');
-        const prHasRelated = pr.linksRelatedTask && pr.linksRelatedTask.split(';').filter(l => l.trim() !== '').length > 0;
+        const prHasRelated = hasLegacyRelatedTasks(pr);
         tr.innerHTML = `
             ${renderTaskIdCell(pr, { includeExpand: true })}
             <td>${pr.summary || '-'}</td>
@@ -1017,13 +1086,12 @@ function createApprovedCard(projectName, projectPrs, currentUser, batchId, batch
                     ${pr.noTestingRequired ? '<span class="tag" style="background:#8250df; color:white; font-size:0.7rem; padding:0.2rem 0.5rem;" title="Não requer testes de QA">Sem Teste</span>' : ''}
                 </div>
             </td>
+            <td>${renderPipelineMatrix(pr)}</td>
             <td style="font-size: 0.8rem; color: var(--text-secondary);">${pr.rollback || '-'}</td>
             <td>
                 <div style="display: flex; gap: 5px; justify-content: flex-end; align-items: center;">
-                    ${pr.teamsLink ? `<a href="${pr.teamsLink}" target="_blank" ${getLinkAttrs('teams-' + pr.id, 'link-icon')} title="Link Teams"><i data-lucide="message-circle" style="width: 16px;"></i></a>` : ''}
-                    ${pr.taskLink ? `<a href="${pr.taskLink}" target="_blank" ${getLinkAttrs('task-' + pr.id, 'link-icon')} title="Link Task"><i data-lucide="external-link" style="width: 14px;"></i></a>` : ''}
-                    ${pr.prLink ? `<a href="${pr.prLink}" target="_blank" ${getLinkAttrs('pr-' + pr.id, 'link-icon')} title="Link PR"><i data-lucide="git-pull-request" style="width: 14px;"></i></a>` : ''}
-                    ${renderRelatedLinks(pr.linksRelatedTask)}
+                    ${renderLinksCell(pr)}
+                    ${renderLegacyRelatedLinks(pr)}
                     ${prRemoveBtn}
                     ${archiveBtn}
                 </div>
@@ -1035,7 +1103,7 @@ function createApprovedCard(projectName, projectPrs, currentUser, batchId, batch
             subRow.id = `related-${pr.id}`;
             subRow.className = 'related-tasks-row';
             subRow.style.display = 'none';
-            subRow.innerHTML = `<td colspan="6">${renderRelatedTasksList(pr.linksRelatedTask, pr.project)}</td>`;
+            subRow.innerHTML = `<td colspan="7">${renderRelatedTasksList(pr.linksRelatedTask, pr.project)}</td>`;
             tbody.appendChild(subRow);
         }
     });
@@ -1130,4 +1198,4 @@ function showLoading(show) {
     if (dbHist) dbHist.style.display = contentDisplay;
 }
 
-export { showToast, renderTable, renderOpenTable, renderApprovedTables, renderTestingTable, renderHistoryTable, showLoading, loadPendingToasts, renderPrHistory, confirmDialog, alertDialog, enableEscapeToCloseModals };
+export { escapeHtml, showToast, renderTable, renderOpenTable, renderApprovedTables, renderTestingTable, renderHistoryTable, showLoading, loadPendingToasts, renderPrHistory, confirmDialog, alertDialog, enableEscapeToCloseModals };

--- a/src/entrega.js
+++ b/src/entrega.js
@@ -10,6 +10,8 @@ import * as LocalStorage from './localStorageService.js';
 import * as DOM from './domService.js';
 import { initializeTheme } from './themeService.js';
 
+// Sem isto o conteúdo gated por papel pisca antes da sessão resolver.
+AuthService.markAuthenticationPending();
 initializeTheme('themeToggleBtn');
 DOM.enableEscapeToCloseModals();
 
@@ -59,6 +61,16 @@ function showError(message) {
 
 async function carregar() {
     try {
+        // Identidade fresca (/Users/me, não o JWT): desde o Épico 9 o token não carrega claim de
+        // Admin, então isAdminGlobal() depende do meCache que restoreSession popula. Sem esta
+        // chamada, um PlatformAdmin/TenantAdmin que não fosse Gestor do app ficava sem o botão
+        // de registrar presença — a tela escondia uma ação que o backend autoriza.
+        const session = await AuthService.restoreSession();
+        if (session.state !== 'ready') {
+            window.location.href = 'index.html';
+            return;
+        }
+
         const apps = await API.fetchApps();
         const app = apps.find(a => a.id === appId);
         if (!app) {

--- a/src/entrega.js
+++ b/src/entrega.js
@@ -1,0 +1,434 @@
+// Visão de detalhe da entrega (Épico 2, 3.2) — rota entrega.html?appId=<uuid>&prId=<id>.
+// Reúne num só lugar o que antes ficava espalhado: onde o PR está em cada degrau da esteira,
+// o ciclo dele, os vínculos (agora adicionáveis e removíveis) e a timeline de eventos.
+//
+// Rota própria, nunca modal — telas de consulta com conteúdo próprio precisam de URL
+// compartilhável e botão voltar (preferências §12).
+import * as API from './apiService.js';
+import * as AuthService from './authService.js';
+import * as LocalStorage from './localStorageService.js';
+import * as DOM from './domService.js';
+import { initializeTheme } from './themeService.js';
+
+initializeTheme('themeToggleBtn');
+DOM.enableEscapeToCloseModals();
+
+LocalStorage.init?.();
+if (!LocalStorage.getItem('token')) {
+    window.location.href = 'index.html';
+}
+
+const params = new URLSearchParams(window.location.search);
+const appId = params.get('appId');
+const prId = params.get('prId');
+
+if (!appId || !prId) {
+    window.location.href = 'index.html';
+}
+
+const loadingEl = document.getElementById('entregaLoading');
+const errorEl = document.getElementById('entregaError');
+const errorTextEl = document.getElementById('entregaErrorText');
+const contentEl = document.getElementById('entregaContent');
+const revertModal = document.getElementById('revertModal');
+
+const KIND_LABELS = { Dev: 'Desenvolvimento', Stg: 'Staging', Prod: 'Produção' };
+const LINK_KIND_LABELS = {
+    Task: 'Task',
+    Pr: 'Pull Request',
+    Communication: 'Comunicação',
+    Pipeline: 'Pipeline',
+    Other: 'Outro',
+};
+
+let prState = null;
+let revertKind = null;
+
+function formatDate(value) {
+    if (!value) return '-';
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? '-' : date.toLocaleString('pt-BR');
+}
+
+function showError(message) {
+    loadingEl.style.display = 'none';
+    contentEl.style.display = 'none';
+    errorEl.style.display = 'block';
+    errorTextEl.textContent = message;
+}
+
+async function carregar() {
+    try {
+        const apps = await API.fetchApps();
+        const app = apps.find(a => a.id === appId);
+        if (!app) {
+            showError('App não encontrado ou sem acesso.');
+            return;
+        }
+        // "Admin"/"QA" nos data-roles = Gestor/QA DESTE app (mesmo mecanismo do dashboard).
+        AuthService.setCurrentAppRole(app.myRole);
+
+        const prs = await API.fetchPRs(false); // false: a entrega pode já ter sido concluída
+        prState = (prs?.prs || []).find(p => String(p.id) === String(prId));
+        if (!prState) {
+            showError('PR não encontrado nesta esteira.');
+            return;
+        }
+
+        document.getElementById('entregaSummary').textContent =
+            `${app.name} - ${prState.summary || `PR #${prState.id}`}`;
+
+        renderMatrix();
+        renderCiclo();
+        renderPresenceActions(app.myRole);
+        await renderLinks();
+        await renderTimeline();
+
+        loadingEl.style.display = 'none';
+        contentEl.style.display = 'grid';
+        AuthService.applyRoleBasedVisibility?.();
+        window.lucide?.createIcons();
+    } catch (error) {
+        console.error('Erro ao carregar a entrega:', error);
+        showError('Não foi possível carregar a entrega. Tente novamente.');
+    }
+}
+
+function renderMatrix() {
+    const container = document.getElementById('entregaMatrix');
+    const steps = prState.environments || [];
+
+    if (steps.length === 0) {
+        container.innerHTML = '<p class="pipeline-empty">Este app ainda não tem esteira configurada.</p>';
+        return;
+    }
+
+    container.innerHTML = '';
+    const dl = document.createElement('dl');
+    dl.className = 'entrega-meta';
+
+    steps.forEach((step) => {
+        const dt = document.createElement('dt');
+        dt.textContent = KIND_LABELS[step.kind] || step.kind;
+
+        const dd = document.createElement('dd');
+        if (!step.present) {
+            dd.textContent = 'Não presente';
+            dd.style.color = 'var(--text-secondary)';
+        } else if (step.mode === 'Individual') {
+            // Sem versão de propósito: na branch de integração o código entra por merge.
+            dd.textContent = `Integrado desde ${formatDate(step.since)}`;
+        } else {
+            dd.textContent = `Versão ${step.version || '-'} desde ${formatDate(step.since)}`;
+        }
+
+        dl.appendChild(dt);
+        dl.appendChild(dd);
+    });
+
+    container.appendChild(dl);
+}
+
+function renderCiclo() {
+    const dl = document.getElementById('entregaCiclo');
+    const entradas = [
+        ['Status', prState.status || '-'],
+        ['Aprovado', prState.approved ? `Sim, por ${prState.approvedBy || '-'}` : 'Não'],
+        ['Em ajustes', prState.needsCorrection ? (prState.correctionReason || 'Sim') : 'Não'],
+        ['Versão', prState.version || 'Sem versão'],
+        ['Sprint', prState.sprint || 'Sem sprint'],
+        ['Em voo', prState.inFlight ? 'Sim' : 'Não, já entregue'],
+        ['Criado em', formatDate(prState.createdAt)],
+    ];
+
+    dl.innerHTML = '';
+    entradas.forEach(([rotulo, valor]) => {
+        const dt = document.createElement('dt');
+        dt.textContent = rotulo;
+        const dd = document.createElement('dd');
+        dd.textContent = valor;
+        dl.appendChild(dt);
+        dl.appendChild(dd);
+    });
+}
+
+/** Registrar/reverter presença é ação de Gestor (D7) e só existe em ambiente de integração. */
+function renderPresenceActions(myRole) {
+    const container = document.getElementById('entregaPresenceActions');
+    container.innerHTML = '';
+
+    const integracao = (prState.environments || []).find(e => e.mode === 'Individual');
+    if (!integracao) return;
+
+    const podeGerir = myRole === 'Gestor' || AuthService.isAdminGlobal?.();
+    if (!podeGerir) return;
+
+    if (integracao.present) {
+        const botao = document.createElement('button');
+        botao.className = 'btn btn-outline';
+        botao.textContent = `Reverter de ${KIND_LABELS[integracao.kind] || integracao.kind}`;
+        botao.addEventListener('click', () => abrirRevert(integracao.kind));
+        container.appendChild(botao);
+        return;
+    }
+
+    const botao = document.createElement('button');
+    botao.className = 'btn btn-primary';
+    botao.textContent = `Registrar em ${KIND_LABELS[integracao.kind] || integracao.kind}`;
+    botao.addEventListener('click', async () => {
+        botao.disabled = true;
+        try {
+            await API.registerPrPresence(appId, prId, integracao.kind);
+            DOM.showToast('Presença registrada na branch de integração.', 'success');
+            window.location.reload();
+        } catch (error) {
+            botao.disabled = false;
+            DOM.showToast(mensagemDeErro(error), 'error');
+        }
+    });
+    container.appendChild(botao);
+}
+
+function mensagemDeErro(error) {
+    const mapa = {
+        already_present: 'Este PR já consta na branch de integração.',
+        environment_is_versioned: 'Este ambiente recebe versão, não PR avulso.',
+        environment_not_in_pipeline: 'Este ambiente não faz parte da esteira do app.',
+        reason_required: 'Informe o motivo do revert.',
+    };
+    if (error?.status === 403) return 'Você não tem permissão para esta ação.';
+    return mapa[error?.body?.error] || error?.message || 'Não foi possível concluir a ação.';
+}
+
+function abrirRevert(kind) {
+    revertKind = kind;
+    limparErro('revertReason');
+    document.getElementById('revertReason').value = '';
+    revertModal.style.display = 'flex';
+}
+
+function fecharRevert() {
+    revertModal.style.display = 'none';
+    revertKind = null;
+}
+
+// Validação inline: borda vermelha no campo + texto junto dele. Toast fica reservado
+// para o resultado da chamada à API (preferências §12).
+function marcarErro(campoId, mensagem) {
+    const campo = document.getElementById(campoId);
+    const erro = document.getElementById(`${campoId}Error`);
+    campo?.classList.add('is-invalid');
+    if (erro) {
+        erro.textContent = mensagem;
+        erro.classList.add('visible'); // .field-error nasce display:none
+    }
+}
+
+function limparErro(campoId) {
+    const campo = document.getElementById(campoId);
+    const erro = document.getElementById(`${campoId}Error`);
+    campo?.classList.remove('is-invalid');
+    if (erro) {
+        erro.textContent = '';
+        erro.classList.remove('visible');
+    }
+}
+
+document.getElementById('revertCancelBtn').addEventListener('click', fecharRevert);
+document.getElementById('revertConfirmBtn').addEventListener('click', async () => {
+    const reason = document.getElementById('revertReason').value.trim();
+    if (!reason) {
+        marcarErro('revertReason', 'Explique por que o código saiu da branch.');
+        return;
+    }
+    limparErro('revertReason');
+
+    try {
+        await API.revertPrPresence(appId, prId, revertKind, reason);
+        DOM.showToast('Revert registrado.', 'success');
+        window.location.reload();
+    } catch (error) {
+        DOM.showToast(mensagemDeErro(error), 'error');
+    }
+});
+
+document.getElementById('revertReason').addEventListener('input', () => limparErro('revertReason'));
+
+async function renderLinks() {
+    const lista = document.getElementById('entregaLinks');
+    lista.innerHTML = '';
+
+    let links = [];
+    try {
+        links = await API.fetchPrLinks(appId, prId) || [];
+    } catch (error) {
+        console.error('Erro ao carregar vínculos:', error);
+    }
+
+    if (links.length === 0) {
+        const vazio = document.createElement('li');
+        vazio.className = 'pipeline-empty';
+        vazio.textContent = 'Nenhum vínculo. Não é obrigatório ter um.';
+        lista.appendChild(vazio);
+        return;
+    }
+
+    links.forEach((link) => {
+        const item = document.createElement('li');
+        item.className = 'link-item';
+
+        const kind = document.createElement('span');
+        kind.className = 'link-item__kind';
+        kind.textContent = LINK_KIND_LABELS[link.kind] || link.kind;
+
+        // textContent, não innerHTML: a URL vem da API e pode ter sido digitada por qualquer um.
+        const anchor = document.createElement('a');
+        anchor.className = 'link-item__url';
+        anchor.href = link.url;
+        anchor.target = '_blank';
+        anchor.rel = 'noopener noreferrer';
+        anchor.textContent = link.label || link.url;
+        anchor.title = link.url;
+
+        const remover = document.createElement('button');
+        remover.className = 'btn btn-outline btn-sm';
+        remover.textContent = 'Remover';
+        remover.addEventListener('click', async () => {
+            remover.disabled = true;
+            try {
+                await API.removePrLink(appId, prId, link.id);
+                DOM.showToast('Vínculo removido.', 'success');
+                await renderLinks();
+            } catch (error) {
+                remover.disabled = false;
+                DOM.showToast(mensagemDeErro(error), 'error');
+            }
+        });
+
+        item.append(kind, anchor, remover);
+        lista.appendChild(item);
+    });
+}
+
+document.getElementById('linkForm').addEventListener('submit', async (event) => {
+    event.preventDefault();
+
+    // Revalida no submit: validar só em input/blur deixa passar quem clica em salvar
+    // sem tirar o foco do campo.
+    const url = document.getElementById('linkUrl').value.trim();
+    const label = document.getElementById('linkLabel').value.trim();
+    limparErro('linkUrl');
+    limparErro('linkLabel');
+
+    if (!url) {
+        marcarErro('linkUrl', 'Informe o endereço do vínculo.');
+        return;
+    }
+    if (url.length > 1000) {
+        marcarErro('linkUrl', 'O endereço passa de 1000 caracteres.');
+        return;
+    }
+    if (label.length > 200) {
+        marcarErro('linkLabel', 'O rótulo passa de 200 caracteres.');
+        return;
+    }
+
+    try {
+        await API.addPrLink(appId, prId, {
+            kind: document.getElementById('linkKind').value,
+            url,
+            label: label || null,
+        });
+        document.getElementById('linkUrl').value = '';
+        document.getElementById('linkLabel').value = '';
+        DOM.showToast('Vínculo adicionado.', 'success');
+        await renderLinks();
+    } catch (error) {
+        DOM.showToast(mensagemDeErro(error), 'error');
+    }
+});
+
+document.getElementById('linkUrl').addEventListener('input', () => limparErro('linkUrl'));
+document.getElementById('linkLabel').addEventListener('input', () => limparErro('linkLabel'));
+
+const EVENT_LABELS = {
+    created: 'PR criado',
+    updated: 'PR atualizado',
+    approved: 'Aprovado',
+    correction_requested: 'Devolvido para ajustes',
+    fixed: 'Marcado como corrigido',
+    version_requested: 'Versão solicitada',
+    deployed_to_staging: 'Implantado em staging',
+    deployed_to_environment: 'Versão implantada',
+    hotfix_deployed: 'Hotfix implantado',
+    merged_to_integration: 'Integrado na branch',
+    reverted_from_integration: 'Revertido da branch',
+    removed_from_batch: 'Removido da versão',
+    link_added: 'Vínculo adicionado',
+    link_removed: 'Vínculo removido',
+    done: 'Concluído',
+    archived: 'Arquivado',
+};
+
+async function renderTimeline() {
+    const container = document.getElementById('entregaTimeline');
+    container.innerHTML = '';
+
+    let eventos = [];
+    try {
+        eventos = await API.fetchPrEvents(prId) || [];
+    } catch (error) {
+        console.error('Erro ao carregar histórico:', error);
+        container.innerHTML = '<p class="pipeline-empty">Não foi possível carregar o histórico.</p>';
+        return;
+    }
+
+    if (eventos.length === 0) {
+        container.innerHTML = '<p class="pipeline-empty">Sem eventos registrados.</p>';
+        return;
+    }
+
+    const dl = document.createElement('dl');
+    dl.className = 'entrega-meta';
+
+    eventos.forEach((evento) => {
+        const dt = document.createElement('dt');
+        dt.textContent = formatDate(evento.createdAt);
+
+        const dd = document.createElement('dd');
+        const titulo = EVENT_LABELS[evento.eventType] || evento.eventType;
+        dd.textContent = `${titulo} - ${evento.actorName || 'sistema'}`;
+
+        // O motivo do hotfix e da devolução é a parte que interessa auditar.
+        const detalhe = extrairDetalhe(evento.detail);
+        if (detalhe) {
+            const nota = document.createElement('div');
+            nota.style.color = 'var(--text-secondary)';
+            nota.style.fontSize = '0.8rem';
+            nota.textContent = detalhe;
+            dd.appendChild(nota);
+        }
+
+        dl.appendChild(dt);
+        dl.appendChild(dd);
+    });
+
+    container.appendChild(dl);
+}
+
+function extrairDetalhe(detail) {
+    if (!detail) return '';
+    try {
+        const dados = typeof detail === 'string' ? JSON.parse(detail) : detail;
+        const partes = [];
+        if (dados.environment) partes.push(`ambiente ${dados.environment}`);
+        if (dados.version) partes.push(`versão ${dados.version}`);
+        if (dados.reason) partes.push(`motivo: ${dados.reason}`);
+        if (dados.url) partes.push(dados.url);
+        return partes.join(' - ');
+    } catch {
+        return '';
+    }
+}
+
+carregar();

--- a/src/environments.js
+++ b/src/environments.js
@@ -1,12 +1,14 @@
-// Ambientes do app (Épico 6) — rota ambientes.html?appId=<uuid>.
-// Coluna por ambiente (dev/stg/prod) com versão atual, histórico expandível,
-// promoção stg → prod e rollback. Dev fica fora do fluxo de deploy nesta fase (6.1.1).
+// Ambientes do app — rota ambientes.html?appId=<uuid>.
+// Um card por degrau da esteira com a versão atual, histórico expandível, promoção e
+// rollback; abaixo, o editor da esteira (Épico 2): ordem, modo, branch e remoção.
 import * as API from './apiService.js';
 import * as AuthService from './authService.js';
 import * as LocalStorage from './localStorageService.js';
 import * as DOM from './domService.js';
 import { initializeTheme } from './themeService.js';
 
+// Sem isto o conteúdo gated por data-roles pisca antes da sessão resolver.
+AuthService.markAuthenticationPending();
 initializeTheme('themeToggleBtn');
 DOM.enableEscapeToCloseModals();
 
@@ -22,34 +24,96 @@ if (!appId) {
 
 const envGrid = document.getElementById('envGrid');
 const promoteModal = document.getElementById('promoteModal');
+const envPageState = document.getElementById('envPageState');
 
 let appState = null;       // { id, name, myRole, ... } vindo de GET /Apps
 let envsState = [];        // [{ id, kind, url, current, monitorName, monitorStatus }]
-let promoteBatch = null;   // o que estava ativo em stg quando o modal abriu (6.4)
+let promoteBatch = null;
+let promoteTarget = null;
 
 const KIND_LABELS = { Dev: 'Desenvolvimento', Stg: 'Staging', Prod: 'Produção' };
 
 async function carregar() {
-    const apps = await API.fetchApps();
-    appState = apps.find(a => a.id === appId);
-    if (!appState) {
-        alert('App não encontrado ou sem acesso.');
-        window.location.href = 'apps.html';
-        return;
+    // Identidade fresca (/Users/me, não o JWT): desde o Épico 9 o token não carrega mais claim
+    // de Admin, então isPlatformAdmin()/isAdminGlobal() dependem do meCache que restoreSession
+    // popula. Sem esta chamada, o editor da esteira — gated por data-roles="Admin" — ficava
+    // invisível para um admin que não fosse Gestor deste app, ou seja, quase sempre.
+    mostrarEstadoPagina('loading', 'Carregando ambientes...');
+    try {
+        const session = await AuthService.restoreSession();
+        if (session.state === 'unauthenticated') {
+            window.location.href = 'index.html';
+            return;
+        }
+        if (session.state !== 'ready') {
+            mostrarEstadoPagina('error', 'A sessão não pôde ser validada agora. Ela foi preservada.', carregar);
+            return;
+        }
+
+        const apps = await API.fetchApps();
+        appState = apps.find(a => a.id === appId);
+        if (!appState) {
+            mostrarEstadoPagina('forbidden', 'App não encontrado ou sem acesso.', () => { window.location.href = 'apps.html'; }, 'Voltar para Apps');
+            return;
+        }
+        document.getElementById('envAppName').textContent =
+            appState.myRole ? `${appState.name} - seu papel: ${appState.myRole}` : appState.name;
+
+        AuthService.setCurrentAppRole(appState.myRole);
+        envsState = await API.fetchEnvironments(appId);
+        esconderEstadoPagina();
+        render();
+    } catch (error) {
+        console.error('Erro ao carregar ambientes:', error);
+        const message = error?.status === 403
+            ? 'Você não tem acesso aos ambientes deste app.'
+            : 'A API não respondeu. Sua sessão foi preservada.';
+        mostrarEstadoPagina(error?.status === 403 ? 'forbidden' : 'error', message, carregar);
     }
-    document.getElementById('envAppName').textContent =
-        appState.myRole ? `${appState.name} - seu papel: ${appState.myRole}` : appState.name;
+}
 
-    // "Admin"/"QA" nos data-roles = Gestor/QA DESTE app (mesmo mecanismo do dashboard, Épico 4.3)
-    AuthService.setCurrentAppRole(appState.myRole);
+function mostrarEstadoPagina(tipo, mensagem, action = null, actionLabel = 'Tentar novamente') {
+    if (!envPageState) return;
+    envPageState.className = `page-state page-state--${tipo}`;
+    envPageState.innerHTML = '';
+    const icon = document.createElement('i');
+    icon.dataset.lucide = tipo === 'loading' ? 'loader-circle' : tipo === 'forbidden' ? 'shield-alert' : 'wifi-off';
+    icon.setAttribute('aria-hidden', 'true');
+    const text = document.createElement('span');
+    text.textContent = mensagem;
+    envPageState.append(icon, text);
+    if (action) {
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.className = 'btn btn-outline btn-sm';
+        button.textContent = actionLabel;
+        button.addEventListener('click', action, { once: true });
+        envPageState.appendChild(button);
+    }
+    envPageState.hidden = false;
+    if (window.lucide) window.lucide.createIcons();
+}
 
-    envsState = await API.fetchEnvironments(appId);
-    render();
+function esconderEstadoPagina() {
+    if (envPageState) envPageState.hidden = true;
 }
 
 function render() {
     envGrid.innerHTML = '';
-    envsState.forEach(env => envGrid.appendChild(cardDoAmbiente(env)));
+    if (envsState.length === 0) {
+        const empty = document.createElement('div');
+        empty.className = 'module-empty-state';
+        const heading = document.createElement('h3');
+        heading.textContent = 'Nenhum ambiente configurado';
+        const guidance = document.createElement('p');
+        guidance.textContent = AuthService.isAdminGlobal() || appState?.myRole === 'Gestor'
+            ? 'Monte a esteira abaixo para começar a acompanhar e implantar versões.'
+            : 'Peça a um gestor do app para configurar a esteira de entrega.';
+        empty.append(heading, guidance);
+        envGrid.appendChild(empty);
+    } else {
+        envsState.forEach(env => envGrid.appendChild(cardDoAmbiente(env)));
+    }
     renderPipelineEditor();
     if (window.lucide) lucide.createIcons();
     AuthService.applyRoleBasedVisibility();
@@ -62,6 +126,27 @@ function render() {
 
 const TODOS_OS_KINDS = ['Dev', 'Stg', 'Prod'];
 let pipelineDraft = null;
+let pipelineDirty = false;
+
+function marcarEsteiraAlterada() {
+    pipelineDirty = true;
+    sincronizarValidacaoEsteira();
+    atualizarEstadoEditor();
+}
+
+function atualizarEstadoEditor() {
+    const save = document.getElementById('pipelineSaveBtn');
+    const reset = document.getElementById('pipelineResetBtn');
+    const erro = validarEsteira();
+    if (save) save.disabled = !pipelineDirty || Boolean(erro);
+    if (reset) reset.disabled = !pipelineDirty;
+}
+
+function sincronizarValidacaoEsteira() {
+    const erro = validarEsteira();
+    marcarErroEsteira(erro || '');
+    return erro;
+}
 
 function renderPipelineEditor() {
     const editor = document.getElementById('pipelineEditor');
@@ -82,21 +167,42 @@ function renderPipelineEditor() {
         const linha = document.createElement('div');
         linha.className = 'pipeline-row';
 
-        const ordem = document.createElement('span');
+        const ordem = document.createElement('div');
         ordem.className = 'pipeline-row__order';
-        ordem.textContent = `${indice + 1}º`;
+        const orderLabel = document.createElement('span');
+        orderLabel.textContent = `${indice + 1}º`;
+        const moverCima = document.createElement('button');
+        moverCima.type = 'button';
+        moverCima.className = 'btn btn-outline btn-sm pipeline-move-btn';
+        moverCima.disabled = indice === 0 || pipelineDraft[indice - 1]?.mode === 'Individual';
+        moverCima.title = `Mover ${KIND_LABELS[passo.kind] || passo.kind} para cima`;
+        moverCima.setAttribute('aria-label', moverCima.title);
+        moverCima.innerHTML = '<i data-lucide="arrow-up" aria-hidden="true"></i>';
+        moverCima.addEventListener('click', () => moverPasso(indice, indice - 1));
+        const moverBaixo = document.createElement('button');
+        moverBaixo.type = 'button';
+        moverBaixo.className = 'btn btn-outline btn-sm pipeline-move-btn';
+        moverBaixo.disabled = indice === pipelineDraft.length - 1 || passo.mode === 'Individual';
+        moverBaixo.title = `Mover ${KIND_LABELS[passo.kind] || passo.kind} para baixo`;
+        moverBaixo.setAttribute('aria-label', moverBaixo.title);
+        moverBaixo.innerHTML = '<i data-lucide="arrow-down" aria-hidden="true"></i>';
+        moverBaixo.addEventListener('click', () => moverPasso(indice, indice + 1));
+        ordem.append(orderLabel, moverCima, moverBaixo);
 
         const kind = document.createElement('select');
         kind.className = 'form-select form-select-sm';
         kind.setAttribute('aria-label', 'Ambiente');
+        kind.setAttribute('aria-describedby', 'pipelineError');
         TODOS_OS_KINDS.forEach((valor) => {
             const opcao = document.createElement('option');
             opcao.value = valor;
             opcao.textContent = KIND_LABELS[valor] || valor;
             opcao.selected = valor === passo.kind;
+            opcao.disabled = valor !== passo.kind
+                && pipelineDraft.some((outro, outroIndice) => outroIndice !== indice && outro.kind === valor);
             kind.appendChild(opcao);
         });
-        kind.addEventListener('change', () => { passo.kind = kind.value; limparErroEsteira(); });
+        kind.addEventListener('change', () => { passo.kind = kind.value; marcarEsteiraAlterada(); renderPipelineEditor(); });
 
         const mode = document.createElement('select');
         mode.className = 'form-select form-select-sm';
@@ -108,7 +214,7 @@ function renderPipelineEditor() {
             opcao.selected = valor === passo.mode;
             mode.appendChild(opcao);
         });
-        mode.addEventListener('change', () => { passo.mode = mode.value; limparErroEsteira(); });
+        mode.addEventListener('change', () => { passo.mode = mode.value; marcarEsteiraAlterada(); });
 
         const branch = document.createElement('input');
         branch.type = 'text';
@@ -117,7 +223,7 @@ function renderPipelineEditor() {
         branch.maxLength = 200;
         branch.value = passo.branch;
         branch.setAttribute('aria-label', 'Branch');
-        branch.addEventListener('input', () => { passo.branch = branch.value; limparErroEsteira(); });
+        branch.addEventListener('input', () => { passo.branch = branch.value; marcarEsteiraAlterada(); });
 
         const remover = document.createElement('button');
         remover.type = 'button';
@@ -126,7 +232,7 @@ function renderPipelineEditor() {
         remover.addEventListener('click', () => {
             pipelineDraft.splice(indice, 1);
             pipelineDraft.forEach((p, i) => { p.order = i + 1; });
-            limparErroEsteira();
+            marcarEsteiraAlterada();
             renderPipelineEditor();
         });
 
@@ -149,11 +255,28 @@ function renderPipelineEditor() {
                 mode: 'Versioned',
                 branch: '',
             });
-            limparErroEsteira();
+            marcarEsteiraAlterada();
             renderPipelineEditor();
         });
         editor.appendChild(adicionar);
     }
+    sincronizarValidacaoEsteira();
+    atualizarEstadoEditor();
+    if (window.lucide) window.lucide.createIcons();
+}
+
+function moverPasso(origem, destino) {
+    if (destino < 0 || destino >= pipelineDraft.length) return;
+    const [passo] = pipelineDraft.splice(origem, 1);
+    pipelineDraft.splice(destino, 0, passo);
+    pipelineDraft.forEach((item, indice) => { item.order = indice + 1; });
+    marcarEsteiraAlterada();
+    renderPipelineEditor();
+    const row = document.querySelectorAll('.pipeline-row')[destino];
+    const buttons = row?.querySelectorAll('.pipeline-move-btn');
+    const preferred = destino > origem ? buttons?.[1] : buttons?.[0];
+    const fallback = destino > origem ? buttons?.[0] : buttons?.[1];
+    (preferred?.disabled ? fallback : preferred)?.focus();
 }
 
 function marcarErroEsteira(mensagem) {
@@ -200,9 +323,11 @@ if (pipelineSaveBtn) {
         }));
 
         pipelineSaveBtn.disabled = true;
+        pipelineSaveBtn.classList.add('is-loading');
         try {
             envsState = await API.updatePipeline(appId, steps);
             pipelineDraft = null;
+            pipelineDirty = false;
             render();
             DOM.showToast('Esteira atualizada.', 'success');
         } catch (error) {
@@ -213,10 +338,12 @@ if (pipelineSaveBtn) {
                 individual_must_be_first: 'O ambiente de integração precisa ser o primeiro.',
                 multiple_individual_environments: 'Só pode haver um ambiente de integração.',
                 pipeline_cannot_be_empty: 'A esteira precisa de pelo menos um ambiente.',
+                kind_duplicated: 'Cada ambiente só pode aparecer uma vez.',
             };
             marcarErroEsteira(mapa[error?.body?.error] || error.message || 'Não foi possível salvar a esteira.');
         } finally {
-            pipelineSaveBtn.disabled = false;
+            pipelineSaveBtn.classList.remove('is-loading');
+            atualizarEstadoEditor();
         }
     });
 }
@@ -225,6 +352,7 @@ const pipelineResetBtn = document.getElementById('pipelineResetBtn');
 if (pipelineResetBtn) {
     pipelineResetBtn.addEventListener('click', () => {
         pipelineDraft = null;
+        pipelineDirty = false;
         limparErroEsteira();
         renderPipelineEditor();
     });
@@ -236,43 +364,66 @@ function cardDoAmbiente(env) {
     card.dataset.kind = env.kind;
 
     const monitor = env.monitorStatus
-        ? `<span class="tag" title="Monitor: ${env.monitorName}"
+        ? `<span class="tag" title="Monitor: ${DOM.escapeHtml(env.monitorName)}"
                style="color: ${env.monitorStatus === 'OK' ? 'var(--success, #2e7d32)' : 'var(--danger, #c62828)'};">
-               ${env.monitorStatus === 'OK' ? '● online' : '● ' + env.monitorStatus}
+               ${env.monitorStatus === 'OK' ? '● online' : '● ' + DOM.escapeHtml(env.monitorStatus)}
            </span>`
         : '';
 
     let corpo;
-    if (env.kind === 'Dev') {
-        // 6.1.1: dev existe no modelo, mas sem fluxo de deploy nesta fase
-        corpo = `<p style="color: var(--text-secondary); font-size: 0.9rem;">Sem deploys registrados.</p>`;
+    if (env.mode === 'Individual') {
+        // Épico 2: ambiente de integração não recebe versão — o código entra por merge, PR a
+        // PR. Mostrar "nenhuma versão implantada" aqui seria descrever o degrau errado.
+        const total = env.presentPrCount ?? 0;
+        corpo = total > 0
+            ? `<p style="margin: 0.3rem 0; font-size: 1.3rem;"><strong>${total}</strong></p>
+               <p style="color: var(--text-secondary); font-size: 0.85rem; margin: 0.2rem 0;">
+                   PR${total === 1 ? '' : 's'} integrado${total === 1 ? '' : 's'}${env.branch ? ` na branch <code>${DOM.escapeHtml(env.branch)}</code>` : ''}
+               </p>`
+            : `<p style="color: var(--text-secondary); font-size: 0.9rem;">
+                   Nenhum PR integrado ainda.${env.branch ? ` Branch <code>${DOM.escapeHtml(env.branch)}</code>.` : ''}
+               </p>
+               <p style="color: var(--text-secondary); font-size: 0.8rem; margin-top: 0.4rem;">
+                   O Gestor registra a entrada de um PR aqui pela tela de entrega.
+               </p>`;
     } else if (env.current) {
         const c = env.current;
         corpo = `
-            <p style="margin: 0.3rem 0; font-size: 1.3rem;"><strong>${c.version || '(sem versão)'}</strong></p>
+            <p style="margin: 0.3rem 0; font-size: 1.3rem;"><strong>${DOM.escapeHtml(c.version || '(sem versão)')}</strong></p>
             <p style="color: var(--text-secondary); font-size: 0.85rem; margin: 0.2rem 0;">
                 ${c.prCount} PR${c.prCount === 1 ? '' : 's'}
-                ${c.deployedBy ? ` &middot; por ${c.deployedBy}` : ''}<br>
+                ${c.deployedBy ? ` &middot; por ${DOM.escapeHtml(c.deployedBy)}` : ''}<br>
                 ${new Date(c.deployedAt).toLocaleString('pt-BR')}
-                ${c.pipelineLink ? ` &middot; <a href="${c.pipelineLink}" target="_blank" rel="noopener">pipeline</a>` : ''}
+                ${c.pipelineLink && /^https?:\/\//i.test(c.pipelineLink) ? ` &middot; <a href="${DOM.escapeHtml(c.pipelineLink)}" target="_blank" rel="noopener">pipeline</a>` : ''}
             </p>`;
     } else {
-        corpo = `<p style="color: var(--text-secondary); font-size: 0.9rem;">Nenhuma versão implantada.</p>`;
+        // Estado vazio com saída: sem isto a tela só dizia "nada aqui" e deixava o usuário
+        // sem saber o que fazer a seguir.
+        const anterior = envsState
+            .filter(e => e.mode === 'Versioned' && e.order < env.order)
+            .sort((a, b) => b.order - a.order)[0];
+        const orientacao = anterior
+            ? `Promova a versão ativa em ${KIND_LABELS[anterior.kind] || anterior.kind}.`
+            : 'Corte uma versão a partir dos PRs aprovados para implantar aqui.';
+        corpo = `<p style="color: var(--text-secondary); font-size: 0.9rem;">Nenhuma versão implantada.</p>
+                 <p style="color: var(--text-secondary); font-size: 0.8rem; margin-top: 0.4rem;">${orientacao}</p>`;
     }
 
-    // visibilidade por papel do app: stg = Gestor/QA ("Admin,QA"), prod = Gestor ("Admin") — 6.3
+    const anteriorVersionado = envsState
+        .filter(item => item.mode === 'Versioned' && item.order < env.order)
+        .sort((a, b) => b.order - a.order)[0];
     const acoes = [];
-    if (env.kind === 'Prod') {
+    if (env.mode === 'Versioned' && anteriorVersionado?.current && env.current?.batchId !== anteriorVersionado.current.batchId) {
         acoes.push(`<button class="btn btn-primary env-promote-btn" data-roles="Admin" type="button">
-            Promover o que está em STG</button>`);
+            Promover de ${KIND_LABELS[anteriorVersionado.kind] || anteriorVersionado.kind}</button>`);
     }
-    if (env.kind !== 'Dev' && env.current) {
-        const roles = env.kind === 'Prod' ? 'Admin' : 'Admin,QA';
-        acoes.push(`<button class="btn btn-outline env-rollback-btn" data-roles="${roles}"
+    if (env.mode === 'Versioned' && env.current) {
+        acoes.push(`<button class="btn btn-outline env-rollback-btn" data-roles="Admin"
             data-kind="${env.kind}" data-deployment="${env.current.id}" type="button">Reverter</button>`);
     }
-    if (env.kind !== 'Dev') {
-        acoes.push(`<button class="btn btn-outline env-history-btn" data-kind="${env.kind}" type="button">
+    if (env.mode === 'Versioned') {
+        acoes.push(`<button class="btn btn-outline env-history-btn" data-kind="${env.kind}" type="button"
+            aria-expanded="false" aria-controls="envHistory-${env.kind}">
             Histórico</button>`);
     }
 
@@ -283,72 +434,112 @@ function cardDoAmbiente(env) {
         </div>
         ${corpo}
         <div style="display: flex; gap: 0.5rem; flex-wrap: wrap; margin-top: 0.8rem;">${acoes.join('')}</div>
-        <div class="env-history" data-kind="${env.kind}" style="display: none; margin-top: 0.8rem;"></div>`;
+        <div id="envHistory-${env.kind}" class="env-history" data-kind="${env.kind}"
+            hidden style="margin-top: 0.8rem;" aria-live="polite"></div>`;
 
-    card.querySelector('.env-promote-btn')?.addEventListener('click', abrirPromocao);
+    card.querySelector('.env-promote-btn')?.addEventListener('click', () => abrirPromocao(env));
     card.querySelector('.env-rollback-btn')?.addEventListener('click', (e) =>
         reverter(e.currentTarget.dataset.kind, e.currentTarget.dataset.deployment));
-    card.querySelector('.env-history-btn')?.addEventListener('click', () => alternarHistorico(card, env.kind));
+    card.querySelector('.env-history-btn')?.addEventListener('click', (event) =>
+        alternarHistorico(card, env.kind, event.currentTarget));
     return card;
 }
 
 // ── Histórico (6.3) ──────────────────────────────────────────────────────────
 
-async function alternarHistorico(card, kind) {
+async function alternarHistorico(card, kind, button) {
     const box = card.querySelector('.env-history');
-    if (box.style.display !== 'none') {
-        box.style.display = 'none';
+    if (!box.hidden) {
+        box.hidden = true;
+        button?.setAttribute('aria-expanded', 'false');
+        if (button) button.textContent = 'Histórico';
         return;
     }
+
+    box.hidden = false;
+    button?.setAttribute('aria-expanded', 'true');
+    if (button) button.textContent = 'Ocultar histórico';
+
     if (!box.dataset.loaded) {
-        const historico = await API.fetchEnvironmentHistory(appId, kind.toLowerCase());
-        box.innerHTML = historico.length === 0
-            ? '<p style="color: var(--text-secondary); font-size: 0.85rem;">Nenhum deploy registrado.</p>'
-            : `<table class="pr-table" style="width: 100%; font-size: 0.85rem;">
+        box.setAttribute('aria-busy', 'true');
+        box.innerHTML = '<p class="env-history__status">Carregando histórico...</p>';
+        try {
+            const historico = await API.fetchEnvironmentHistory(appId, kind.toLowerCase());
+            box.innerHTML = historico.length === 0
+                ? `<div class="module-empty-state module-empty-state--compact">
+                    <h4>Nenhum deploy registrado</h4>
+                    <p>O histórico será exibido depois da primeira implantação neste ambiente.</p>
+                   </div>`
+                : `<table class="pr-table" style="width: 100%; font-size: 0.85rem;">
                 <thead><tr><th>Versão</th><th>Quando</th><th>Por</th><th>Status</th></tr></thead>
                 <tbody>${historico.map(h => `
                     <tr>
-                        <td>${h.version || '(sem versão)'}</td>
+                        <td>${DOM.escapeHtml(h.version || '(sem versão)')}</td>
                         <td>${new Date(h.deployedAt).toLocaleString('pt-BR')}</td>
-                        <td>${h.deployedBy || '-'}</td>
-                        <td>${traduzStatus(h.status)}</td>
+                        <td>${DOM.escapeHtml(h.deployedBy || '-')}</td>
+                        <td>${DOM.escapeHtml(traduzStatus(h.status))}</td>
                     </tr>`).join('')}
                 </tbody></table>`;
-        box.dataset.loaded = '1';
+            box.dataset.loaded = '1';
+        } catch (error) {
+            console.error(`Erro ao carregar histórico de ${kind}:`, error);
+            box.innerHTML = '';
+            const mensagem = document.createElement('p');
+            mensagem.className = 'env-history__status env-history__status--error';
+            mensagem.textContent = 'Não foi possível carregar o histórico.';
+            const tentar = document.createElement('button');
+            tentar.type = 'button';
+            tentar.className = 'btn btn-outline btn-sm';
+            tentar.textContent = 'Tentar novamente';
+            tentar.addEventListener('click', () => {
+                delete box.dataset.loaded;
+                box.hidden = true;
+                alternarHistorico(card, kind, button);
+            }, { once: true });
+            box.append(mensagem, tentar);
+        } finally {
+            box.removeAttribute('aria-busy');
+        }
     }
-    box.style.display = 'block';
 }
 
 function traduzStatus(status) {
     return { Active: 'Ativo', Superseded: 'Substituído', RolledBack: 'Revertido' }[status] || status;
 }
 
-// ── Promoção stg → prod (6.4) ────────────────────────────────────────────────
+// ── Promoção entre degraus configurados (6.4) ───────────────────────────────
 
-function abrirPromocao() {
-    const stg = envsState.find(e => e.kind === 'Stg');
-    if (!stg?.current) {
-        alert('Não há nenhuma versão ativa em staging para promover.');
+function abrirPromocao(targetEnv) {
+    const source = envsState
+        .filter(env => env.mode === 'Versioned' && env.order < targetEnv.order)
+        .sort((a, b) => b.order - a.order)[0];
+    if (!source?.current) {
+        DOM.showToast('Não há uma versão ativa no ambiente anterior.', 'warning');
         return;
     }
-    promoteBatch = stg.current; // lido na hora de abrir o modal; o servidor revalida (6.1.2)
+    promoteBatch = source.current;
+    promoteTarget = targetEnv;
+    document.getElementById('promoteTitle').textContent = `Promover para ${KIND_LABELS[targetEnv.kind] || targetEnv.kind}`;
     document.getElementById('promoteSummary').innerHTML = `
-        <p>Vai subir para <strong>produção</strong>:</p>
-        <p style="font-size: 1.2rem; margin: 0.4rem 0;"><strong>${promoteBatch.version || '(sem versão)'}</strong></p>
+        <p>Vai de <strong>${KIND_LABELS[source.kind] || source.kind}</strong> para <strong>${KIND_LABELS[targetEnv.kind] || targetEnv.kind}</strong>:</p>
+        <p style="font-size: 1.2rem; margin: 0.4rem 0;"><strong>${DOM.escapeHtml(promoteBatch.version || '(sem versão)')}</strong></p>
         <p style="color: var(--text-secondary); font-size: 0.85rem;">
             ${promoteBatch.prCount} PR${promoteBatch.prCount === 1 ? '' : 's'} incluído${promoteBatch.prCount === 1 ? '' : 's'}
-            &middot; em staging desde ${new Date(promoteBatch.deployedAt).toLocaleString('pt-BR')}
+            &middot; em ${KIND_LABELS[source.kind] || source.kind} desde ${new Date(promoteBatch.deployedAt).toLocaleString('pt-BR')}
         </p>`;
     promoteModal.style.display = 'flex';
 }
 
 document.getElementById('promoteConfirmBtn')?.addEventListener('click', async () => {
-    if (!promoteBatch) return;
+    if (!promoteBatch || !promoteTarget) return;
     try {
-        await API.deployToEnvironment(appId, 'prod', promoteBatch.batchId);
+        await API.deployToEnvironment(appId, promoteTarget.kind.toLowerCase(), promoteBatch.batchId);
         promoteModal.style.display = 'none';
         envsState = await API.fetchEnvironments(appId);
+        pipelineDraft = null;
+        pipelineDirty = false;
         render();
+        DOM.showToast(`Versão promovida para ${KIND_LABELS[promoteTarget.kind] || promoteTarget.kind}.`, 'success');
     } catch (error) {
         promoteModal.style.display = 'none';
         await tratarErro(error);
@@ -358,7 +549,12 @@ document.getElementById('promoteConfirmBtn')?.addEventListener('click', async ()
 // ── Rollback (6.1.3) ─────────────────────────────────────────────────────────
 
 async function reverter(kind, deploymentId) {
-    if (!confirm('Reverter para a versão anterior?')) return;
+    const confirmed = await DOM.confirmDialog(
+        `Reverter ${KIND_LABELS[kind] || kind} para a versão anterior?`,
+        'Confirmar rollback',
+        { confirmLabel: 'Reverter', danger: true },
+    );
+    if (!confirmed) return;
     try {
         await API.rollbackDeployment(appId, kind.toLowerCase(), deploymentId);
         envsState = await API.fetchEnvironments(appId);
@@ -372,19 +568,27 @@ async function reverter(kind, deploymentId) {
 
 async function tratarErro(error) {
     if (error.status === 403) {
-        alert('Você não tem papel suficiente neste app para essa ação.');
+        DOM.showToast('Você não tem papel suficiente neste app para essa ação.', 'error');
     } else if (error.status === 409) {
-        alert('O estado do ambiente mudou, atualizando...');
+        DOM.showToast('O estado do ambiente mudou. A tela foi atualizada.', 'warning');
     } else {
-        alert(`Erro: ${error.message}`);
+        DOM.showToast(error.message || 'Não foi possível concluir a ação.', 'error');
     }
-    envsState = await API.fetchEnvironments(appId);
-    render();
+    try {
+        envsState = await API.fetchEnvironments(appId);
+        pipelineDraft = null;
+        pipelineDirty = false;
+        render();
+    } catch (refreshError) {
+        mostrarEstadoPagina('error', 'Não foi possível atualizar os ambientes.', carregar);
+    }
 }
 
 document.querySelectorAll('.close-btn, .close-modal').forEach(btn =>
     btn.addEventListener('click', () => {
         promoteModal.style.display = 'none';
+        promoteBatch = null;
+        promoteTarget = null;
     }));
 
 carregar();

--- a/src/environments.js
+++ b/src/environments.js
@@ -50,8 +50,184 @@ async function carregar() {
 function render() {
     envGrid.innerHTML = '';
     envsState.forEach(env => envGrid.appendChild(cardDoAmbiente(env)));
+    renderPipelineEditor();
     if (window.lucide) lucide.createIcons();
     AuthService.applyRoleBasedVisibility();
+}
+
+// ── Esteira configurável (Épico 2, D4) ──────────────────────────────────────
+// Edita a esteira inteira e salva de uma vez: ordem, modo e branch de cada degrau.
+// Salvar substitui a configuração completa — o que sair da lista é removido, e o
+// backend recusa remover ambiente que já tem deployment ou presença.
+
+const TODOS_OS_KINDS = ['Dev', 'Stg', 'Prod'];
+let pipelineDraft = null;
+
+function renderPipelineEditor() {
+    const editor = document.getElementById('pipelineEditor');
+    if (!editor) return;
+
+    if (pipelineDraft === null) {
+        pipelineDraft = envsState.map(env => ({
+            kind: env.kind,
+            order: env.order,
+            mode: env.mode,
+            branch: env.branch || '',
+        })).sort((a, b) => a.order - b.order);
+    }
+
+    editor.innerHTML = '';
+
+    pipelineDraft.forEach((passo, indice) => {
+        const linha = document.createElement('div');
+        linha.className = 'pipeline-row';
+
+        const ordem = document.createElement('span');
+        ordem.className = 'pipeline-row__order';
+        ordem.textContent = `${indice + 1}º`;
+
+        const kind = document.createElement('select');
+        kind.className = 'form-select form-select-sm';
+        kind.setAttribute('aria-label', 'Ambiente');
+        TODOS_OS_KINDS.forEach((valor) => {
+            const opcao = document.createElement('option');
+            opcao.value = valor;
+            opcao.textContent = KIND_LABELS[valor] || valor;
+            opcao.selected = valor === passo.kind;
+            kind.appendChild(opcao);
+        });
+        kind.addEventListener('change', () => { passo.kind = kind.value; limparErroEsteira(); });
+
+        const mode = document.createElement('select');
+        mode.className = 'form-select form-select-sm';
+        mode.setAttribute('aria-label', 'Modo');
+        [['Individual', 'Integração (PR a PR)'], ['Versioned', 'Versão']].forEach(([valor, rotulo]) => {
+            const opcao = document.createElement('option');
+            opcao.value = valor;
+            opcao.textContent = rotulo;
+            opcao.selected = valor === passo.mode;
+            mode.appendChild(opcao);
+        });
+        mode.addEventListener('change', () => { passo.mode = mode.value; limparErroEsteira(); });
+
+        const branch = document.createElement('input');
+        branch.type = 'text';
+        branch.className = 'form-control form-control-sm';
+        branch.placeholder = 'branch (opcional)';
+        branch.maxLength = 200;
+        branch.value = passo.branch;
+        branch.setAttribute('aria-label', 'Branch');
+        branch.addEventListener('input', () => { passo.branch = branch.value; limparErroEsteira(); });
+
+        const remover = document.createElement('button');
+        remover.type = 'button';
+        remover.className = 'btn btn-outline btn-sm';
+        remover.textContent = 'Remover';
+        remover.addEventListener('click', () => {
+            pipelineDraft.splice(indice, 1);
+            pipelineDraft.forEach((p, i) => { p.order = i + 1; });
+            limparErroEsteira();
+            renderPipelineEditor();
+        });
+
+        linha.append(ordem, kind, mode, branch, remover);
+        editor.appendChild(linha);
+    });
+
+    const kindsUsados = pipelineDraft.map(p => p.kind);
+    const disponivel = TODOS_OS_KINDS.find(k => !kindsUsados.includes(k));
+    if (disponivel) {
+        const adicionar = document.createElement('button');
+        adicionar.type = 'button';
+        adicionar.className = 'btn btn-outline btn-sm';
+        adicionar.style.alignSelf = 'flex-start';
+        adicionar.textContent = 'Adicionar ambiente';
+        adicionar.addEventListener('click', () => {
+            pipelineDraft.push({
+                kind: disponivel,
+                order: pipelineDraft.length + 1,
+                mode: 'Versioned',
+                branch: '',
+            });
+            limparErroEsteira();
+            renderPipelineEditor();
+        });
+        editor.appendChild(adicionar);
+    }
+}
+
+function marcarErroEsteira(mensagem) {
+    const erro = document.getElementById('pipelineError');
+    if (!erro) return;
+    erro.textContent = mensagem;
+    erro.classList.toggle('visible', Boolean(mensagem)); // .field-error nasce display:none
+}
+
+function limparErroEsteira() {
+    marcarErroEsteira('');
+}
+
+// As mesmas regras existem no backend — esta validação é feedback imediato, não barreira.
+function validarEsteira() {
+    if (pipelineDraft.length === 0) return 'A esteira precisa de pelo menos um ambiente.';
+
+    const kinds = pipelineDraft.map(p => p.kind);
+    if (new Set(kinds).size !== kinds.length) return 'Cada ambiente só pode aparecer uma vez.';
+
+    const individuais = pipelineDraft.filter(p => p.mode === 'Individual');
+    if (individuais.length > 1) return 'Só pode haver um ambiente de integração.';
+    if (individuais.length === 1 && pipelineDraft.indexOf(individuais[0]) !== 0) {
+        return 'O ambiente de integração precisa ser o primeiro da esteira.';
+    }
+    return null;
+}
+
+const pipelineSaveBtn = document.getElementById('pipelineSaveBtn');
+if (pipelineSaveBtn) {
+    pipelineSaveBtn.addEventListener('click', async () => {
+        const erro = validarEsteira();
+        if (erro) {
+            marcarErroEsteira(erro);
+            return;
+        }
+        limparErroEsteira();
+
+        const steps = pipelineDraft.map((passo, indice) => ({
+            kind: passo.kind,
+            order: indice + 1,
+            mode: passo.mode,
+            branch: passo.branch.trim() || null,
+        }));
+
+        pipelineSaveBtn.disabled = true;
+        try {
+            envsState = await API.updatePipeline(appId, steps);
+            pipelineDraft = null;
+            render();
+            DOM.showToast('Esteira atualizada.', 'success');
+        } catch (error) {
+            const mapa = {
+                environment_has_deployments: 'Não dá para remover um ambiente que já recebeu deploy ou presença.',
+                environment_mode_locked: 'Não dá para trocar o modo de um ambiente que já tem histórico.',
+                order_must_be_sequential: 'A ordem precisa começar em 1 e não ter buracos.',
+                individual_must_be_first: 'O ambiente de integração precisa ser o primeiro.',
+                multiple_individual_environments: 'Só pode haver um ambiente de integração.',
+                pipeline_cannot_be_empty: 'A esteira precisa de pelo menos um ambiente.',
+            };
+            marcarErroEsteira(mapa[error?.body?.error] || error.message || 'Não foi possível salvar a esteira.');
+        } finally {
+            pipelineSaveBtn.disabled = false;
+        }
+    });
+}
+
+const pipelineResetBtn = document.getElementById('pipelineResetBtn');
+if (pipelineResetBtn) {
+    pipelineResetBtn.addEventListener('click', () => {
+        pipelineDraft = null;
+        limparErroEsteira();
+        renderPipelineEditor();
+    });
 }
 
 function cardDoAmbiente(env) {

--- a/src/script.js
+++ b/src/script.js
@@ -933,8 +933,12 @@ async function confirmRequestVersionSelection() {
     }
 }
 
+// Épico 2 (D6): "em voo" — integrado e ainda não entregue. É filtro de consulta, então a
+// preferência do usuário vira parâmetro da API, não um estado gravado no PR.
+let showOnlyInFlight = true;
+
 async function loadPrTablesData(animate = false, expectedRevision = tenantOperations.snapshot()) {
-    const prResult = await API.fetchPRs();
+    const prResult = await API.fetchPRs(showOnlyInFlight);
     if (!tenantOperations.isCurrent(expectedRevision)) return false;
     if (!prResult || !Array.isArray(prResult.prs)) {
         throw new Error('Falha ao carregar PRs');
@@ -1140,6 +1144,22 @@ function openAddModal() {
 }
 
 document.getElementById('addPrBtn').addEventListener('click', openAddModal);
+
+// Alterna entre "em voo" e a lista completa. Recarrega da API porque o filtro é derivado
+// lá (presença + versão no último ambiente), não uma propriedade que o cliente possa calcular.
+const inFlightToggle = document.getElementById('inFlightToggle');
+if (inFlightToggle) {
+    inFlightToggle.addEventListener('change', async (event) => {
+        showOnlyInFlight = event.target.checked;
+        try {
+            await loadPrTablesData(true);
+        } catch (error) {
+            console.error('Erro ao alternar o filtro de PRs em voo:', error);
+            DOM.showToast('Não foi possível recarregar a lista de PRs.', 'error');
+        }
+    });
+}
+
 if (document.getElementById('setupBtn')) {
     document.getElementById('setupBtn').addEventListener('click', openSetupModal);
 }

--- a/src/script.js
+++ b/src/script.js
@@ -14,7 +14,7 @@ import * as Form from './formService.js';
 import { createTenantOperationGuard } from './tenantOperationGuard.js';
 import { findDeveloperById, resolveDeveloperId } from './developerSelection.js';
 
-let currentData = { prs: [] };
+let currentData = { prs: [], batches: [], sprints: [], apps: [] };
 let availableUsers = [];
 const tenantOperations = createTenantOperationGuard();
 
@@ -40,6 +40,7 @@ async function loadProjectOptions(expectedRevision = tenantOperations.snapshot()
         const apps = await API.fetchApps();
         if (!tenantOperations.isCurrent(expectedRevision)) return false;
         if (!Array.isArray(apps)) return;
+        currentData.apps = apps;
 
         if (projectSelect) {
             projectSelect.innerHTML = '';
@@ -58,6 +59,7 @@ async function loadProjectOptions(expectedRevision = tenantOperations.snapshot()
         }
 
         updateProjectEmptyState(apps);
+        popularFiltroDeApp(apps);
 
         if (appFilter) {
             const app = apps.find(a => a.name === appFilter);
@@ -72,6 +74,10 @@ async function loadProjectOptions(expectedRevision = tenantOperations.snapshot()
                 projectSelect.disabled = true;
                 projectSelect.title = 'Projeto herdado do app selecionado';
             }
+
+            await carregarEsteiraDoApp();
+        } else if (filtros.app) {
+            await carregarEsteiraDoApp(filtros.app);
         }
         return true;
     } catch (error) {
@@ -134,7 +140,7 @@ function populateDeveloperSelect() {
 }
 
 function setPrCreationRequiredState(isCreate) {
-    const fields = ['project', 'dev', 'summary', 'prLink', 'taskLink', 'teamsLink'];
+    const fields = ['project', 'dev', 'summary'];
     fields.forEach(id => {
         const field = document.getElementById(id);
         if (field) field.required = isCreate;
@@ -145,29 +151,11 @@ function validatePrForm(isCreate) {
     const project = document.getElementById('project');
     const dev = document.getElementById('dev');
     const summary = document.getElementById('summary');
-    const prLink = document.getElementById('prLink');
-    const taskLink = document.getElementById('taskLink');
-    const teamsLink = document.getElementById('teamsLink');
     const rules = [
         { field: project, validate: Form.isRequired, message: 'Selecione uma aplicação.' },
         { field: dev, validate: value => Boolean(findDeveloperById(availableUsers, value)), message: 'Selecione um desenvolvedor válido da lista.' },
         { field: summary, validate: Form.isRequired, message: 'Informe o resumo do PR.' },
-        { field: prLink, validate: value => (!isCreate || Form.isRequired(value)) && Form.isOptionalUrl(value), message: 'Informe uma URL válida para o PR.' },
-        { field: taskLink, validate: value => (!isCreate || Form.isRequired(value)) && Form.isOptionalUrl(value), message: 'Informe uma URL válida para a task.' },
-        { field: teamsLink, validate: value => (!isCreate || Form.isRequired(value)) && Form.isOptionalUrl(value), message: 'Informe uma URL válida para o post no Teams.' },
     ];
-
-    document.querySelectorAll('.related-task-group').forEach(group => {
-        const urlField = group.querySelector('.related-task-input-url');
-        const summaryField = group.querySelector('.related-task-input-summary');
-        rules.push({
-            field: urlField,
-            validate: value => Form.isRequired(value)
-                ? Form.isOptionalUrl(value)
-                : !Form.isRequired(summaryField?.value),
-            message: 'Informe uma URL válida para a task relacionada.'
-        });
-    });
 
     return Form.validateFields(rules);
 }
@@ -177,9 +165,6 @@ function getPrErrorMessage(errorMessage) {
         project_required: 'Projeto é obrigatório.',
         summary_required: 'Resumo é obrigatório.',
         dev_required: 'Desenvolvedor é obrigatório.',
-        pr_link_required: 'Link PR é obrigatório.',
-        task_link_required: 'Link Task (Jira) é obrigatório.',
-        teams_link_required: 'Post no Teams é obrigatório.',
     };
 
     return friendlyMessages[errorMessage] || errorMessage;
@@ -192,12 +177,27 @@ const requestVersionModal = document.getElementById('requestVersionModal');
 const requestVersionDevSelect = document.getElementById('requestVersionDevSelect');
 const requestVersionModalDescription = document.getElementById('requestVersionModalDescription');
 const confirmRequestVersionModalBtn = document.getElementById('confirmRequestVersionModalBtn');
+const hotfixModal = document.getElementById('hotfixModal');
+const hotfixReasonInput = document.getElementById('hotfixReason');
+let pendingHotfixBatchId = null;
 const newSprintModal = document.getElementById('newSprintModal');
 const newSprintNameInput = document.getElementById('newSprintNameInput');
 const newSprintNameError = document.getElementById('newSprintNameError');
 const newSprintStartDateInput = document.getElementById('newSprintStartDateInput');
 const newSprintEndDateInput = document.getElementById('newSprintEndDateInput');
 const confirmNewSprintBtn = document.getElementById('confirmNewSprintBtn');
+let modalReturnFocus = null;
+
+function openAccessibleModal(modal, preferredElement = null) {
+    if (!modal) return;
+    modalReturnFocus = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    modal.style.display = 'flex';
+    requestAnimationFrame(() => {
+        const target = preferredElement
+            || modal.querySelector('input:not(:disabled), select:not(:disabled), textarea:not(:disabled), button:not(:disabled)');
+        target?.focus({ preventScroll: true });
+    });
+}
 
 const sprintDateRangePicker = initDateRangePicker({
     fieldEl: document.getElementById('sprintDateRangeField'),
@@ -217,6 +217,7 @@ const sprintDateRangePicker = initDateRangePicker({
 });
 const prForm = document.getElementById('prForm');
 const profileScreen = document.getElementById('profileScreen');
+const loginCancelBtn = document.getElementById('loginCancelBtn');
 const currentUserDisplay = document.getElementById('currentUserDisplay');
 const currentUserDisplayRight = document.getElementById('currentUserDisplayRight');
 const godModeContainer = document.getElementById('godModeContainer');
@@ -241,14 +242,20 @@ function hideLoginGate() {
     profileScreen.style.display = 'none';
     document.body.classList.remove('no-scroll');
     if (appShell) appShell.inert = false;
+    if (loginCancelBtn) loginCancelBtn.hidden = true;
+    if (LocalStorage.getItem('token')) AuthService.applyRoleBasedVisibility();
 }
 
 function showLoginGate() {
     if (!profileScreen) return;
+    const podeCancelar = Boolean(LocalStorage.getItem('token') && LocalStorage.getItem('appUser'));
+    if (loginCancelBtn) loginCancelBtn.hidden = !podeCancelar;
     profileScreen.style.display = 'flex';
     document.body.classList.add('no-scroll');
     if (appShell) appShell.inert = true;
 }
+
+loginCancelBtn?.addEventListener('click', hideLoginGate);
 
 // Click outside to close profile selection if user already selected
 if (profileScreen) {
@@ -266,6 +273,12 @@ window.addEventListener('keydown', (e) => {
         // Esc só dispensa o gate quando já existe sessão (troca de usuário) — no login
         // inicial ele é bloqueante mesmo, não há para onde voltar.
         if (e.key === 'Escape' && LocalStorage.getItem('appUser')) hideLoginGate();
+        return;
+    }
+
+    if (e.key === 'Escape') {
+        e.preventDefault();
+        closeAllModals();
         return;
     }
 
@@ -291,8 +304,6 @@ window.addEventListener('keydown', (e) => {
     } else if (key === '?' || (e.shiftKey && e.key === '?')) {
         e.preventDefault();
         shortcutsModal.style.display = 'flex';
-    } else if (e.key === 'Escape') {
-        closeAllModals();
     } else if ((e.ctrlKey || e.metaKey) && e.shiftKey && key === 'k') {
         e.preventDefault();
         
@@ -401,6 +412,11 @@ if (godModeInput) {
 // toda chamada à API depois disso já sai com o header X-Tenant-Id certo.
 async function ensureTenantContext() {
     const session = await AuthService.restoreSession();
+    if (session.state === 'unavailable') {
+        setDashboardLoadError('A API está temporariamente indisponível. Sua sessão e seus filtros foram preservados.');
+        DOM.showLoading(false);
+        return false;
+    }
     if (session.state === 'unauthenticated') {
         showProfileSelection();
         return false;
@@ -427,6 +443,17 @@ async function ensureTenantContext() {
     updateTenantSwitcher();
     return true;
 }
+
+function setDashboardLoadError(message = '') {
+    const state = document.getElementById('dashboardLoadError');
+    const text = document.getElementById('dashboardLoadErrorText');
+    if (!state || !text) return;
+    state.hidden = !message;
+    text.textContent = message;
+    if (message && window.lucide) window.lucide.createIcons();
+}
+
+document.getElementById('dashboardRetryBtn')?.addEventListener('click', () => window.location.reload());
 
 // dismissValue: tenantId a resolver quando o usuário fecha via Esc/clique fora, sem escolher
 // nada. Só faz sentido quando já existe um tenant atual válido (troca voluntária pelo
@@ -494,6 +521,13 @@ document.getElementById('tenantSwitchBtn')?.addEventListener('click', async () =
         const chosenId = await showTenantSelector(me.tenants, currentTenantId);
         if (chosenId === currentTenantId) return;
 
+        // Nada da tela pode sobreviver à troca. Os botões renderizados carregam o id do PR no
+        // onclick, e ids de PR são GLOBAIS, não por tenant: clicar em aprovar num resto de
+        // render do tenant anterior manda um id que o backend não enxerga mais, e volta 404.
+        // Esvaziar antes de carregar é preferível a mostrar dado do tenant errado, inclusive
+        // se a carga abaixo falhar no meio.
+        limparDadosDaTela();
+
         DOM.showLoading(true);
         const activatedMe = await AuthService.activateTenant(chosenId);
         if (!tenantOperations.isCurrent(transitionRevision)) return;
@@ -528,14 +562,28 @@ document.getElementById('noTenantLogoutBtn')?.addEventListener('click', async ()
     showProfileSelection();
 });
 
+/** Zera o estado e re-renderiza vazio, para não restar botão apontando para o tenant anterior. */
+function limparDadosDaTela() {
+    currentData.prs = [];
+    currentData.batches = [];
+    currentData.sprints = [];
+    esteirasPorApp.clear();
+    refreshOpenPrs();
+    refreshApprovedPrs();
+    refreshTestingAndHistory();
+}
+
 function closeAllModals() {
     prModal.style.display = 'none';
     Form.resetFormState(prForm);
     if (setupModal) setupModal.style.display = 'none';
     if (shortcutsModal) shortcutsModal.style.display = 'none';
     if (requestVersionModal) requestVersionModal.style.display = 'none';
+    if (hotfixModal) hotfixModal.style.display = 'none';
     if (newSprintModal) newSprintModal.style.display = 'none';
     pendingVersionRequestContext = null;
+    if (modalReturnFocus?.isConnected) modalReturnFocus.focus({ preventScroll: true });
+    modalReturnFocus = null;
     
     if (LocalStorage.getItem('appUser')) {
         hideLoginGate();
@@ -774,7 +822,11 @@ function showProfileSelection() {
     clearLoginErrors();
     setLoginSubmitting(false);
     resetLoginPasswordToggle();
-    AuthService.markAuthenticationPending();
+    // Na troca voluntária o dashboard continua autenticado e pode ser restaurado.
+    // O estado pendente só é correto no login inicial ou depois de um logout.
+    if (!(LocalStorage.getItem('token') && LocalStorage.getItem('appUser'))) {
+        AuthService.markAuthenticationPending();
+    }
 
     showLoginGate();
     document.getElementById('loginIdentifier')?.focus();
@@ -879,11 +931,12 @@ function openRequestVersionModal(prIds, projectName) {
     populateRequestVersionDevSelect(currentUserId || '');
 
     if (requestVersionModalDescription) {
-        requestVersionModalDescription.textContent = `Selecione o dev que vai preencher a versão, número da release, link do pipeline e rollback do lote "${pendingVersionRequestContext.projectName}".`;
+        const total = pendingVersionRequestContext.prIds.length;
+        requestVersionModalDescription.textContent = `Selecione o dev que vai preencher a versão, número da release, link do pipeline e rollback do lote "${pendingVersionRequestContext.projectName}" (${total} PR${total === 1 ? '' : 's'}).`;
     }
 
     if (requestVersionModal) {
-        requestVersionModal.style.display = 'flex';
+        openAccessibleModal(requestVersionModal, requestVersionDevSelect);
     }
 }
 
@@ -907,21 +960,37 @@ async function confirmRequestVersionSelection() {
 
     const { prIds, projectName } = pendingVersionRequestContext;
 
-    if (!confirm(`Solicitar versão para ${prIds.length} PRs aprovados de "${projectName}" e direcionar para ${selectedDev.name}?`)) {
+    const confirmed = await DOM.confirmDialog(
+        `Empacotar ${prIds.length} PRs aprovados de "${projectName}" e direcionar para ${selectedDev.name}?`,
+        'Empacotar PRs',
+        { confirmLabel: 'Empacotar PRs' },
+    );
+    if (!confirmed) {
         return;
     }
 
     try {
         DOM.showLoading(true);
 
-        await API.requestVersionBatch(prIds, selectedDev.id, selectedDev.name);
+        const resultado = await API.requestVersionBatch(prIds, selectedDev.id, selectedDev.name);
 
         if (requestVersionModal) {
             requestVersionModal.style.display = 'none';
         }
         pendingVersionRequestContext = null;
 
-        DOM.showToast(`Versão solicitada para ${selectedDev.name}!`);
+        // O backend pula PR que já tem versão ou já está em outro lote. Sem dizer isso na tela,
+        // o lote saía menor do que o pedido e ninguém ficava sabendo.
+        const pulados = resultado?.skipped ?? [];
+        if (pulados.length > 0) {
+            DOM.showToast(
+                `Versão solicitada para ${selectedDev.name}, mas ${pulados.length} PR(s) ficaram de fora: `
+                + pulados.map(pr => pr.externalId || `#${pr.id}`).join(', '),
+                'warning',
+            );
+        } else {
+            DOM.showToast(`Versão solicitada para ${selectedDev.name}!`);
+        }
         await loadData(true);
     } catch (error) {
         console.error('Erro ao solicitar versão:', error);
@@ -933,10 +1002,80 @@ async function confirmRequestVersionSelection() {
 
 // Épico 2 (D6): "em voo" — integrado e ainda não entregue. É filtro de consulta, então a
 // preferência do usuário vira parâmetro da API, não um estado gravado no PR.
-let showOnlyInFlight = true;
+const initialQuery = new URLSearchParams(window.location.search);
+let showOnlyInFlight = initialQuery.get('inFlight') !== 'false';
+
+// Esteira do app selecionado. Guardada porque a tela precisa dela em dois lugares: o rótulo
+// da seção de validação e o filtro por ambiente.
+let esteiraDoApp = [];
+const esteirasPorApp = new Map();
+
+const KIND_LABELS = { Dev: 'Desenvolvimento', Stg: 'Staging', Prod: 'Produção' };
+
+/**
+ * Carrega a esteira do app e ajusta o que dependia de "STG" fixo.
+ *
+ * O título da seção anunciava "Versões em Teste (STG)" para qualquer app — mentira num app
+ * configurado como dev → prod, que não tem staging. O rótulo passa a nomear o ambiente real
+ * onde as versões são validadas: o último degrau versionado ANTES do de produção.
+ */
+async function carregarEsteira(appId) {
+    if (!appId) return [];
+    if (esteirasPorApp.has(appId)) return esteirasPorApp.get(appId);
+    const envs = await API.fetchEnvironments(appId);
+    const esteira = Array.isArray(envs) ? [...envs].sort((a, b) => a.order - b.order) : [];
+    esteirasPorApp.set(appId, esteira);
+    return esteira;
+}
+
+async function carregarEsteiraDoApp(appId = currentAppId || filtros.app) {
+    if (!appId) {
+        esteiraDoApp = [];
+        atualizarRotuloValidacao();
+        popularFiltroDeAmbiente();
+        return;
+    }
+
+    try {
+        esteiraDoApp = await carregarEsteira(appId);
+    } catch (error) {
+        console.error('Erro ao carregar a esteira do app:', error);
+        esteiraDoApp = [];
+    }
+
+    atualizarRotuloValidacao();
+    popularFiltroDeAmbiente();
+}
+
+function ambienteDeValidacao() {
+    return ambienteDeValidacaoDaEsteira(esteiraDoApp);
+}
+
+function ambienteDeValidacaoDaEsteira(esteira) {
+    const versionados = esteira.filter(e => e.mode === 'Versioned');
+    // O último degrau é produção; o anterior é onde a versão fica em validação.
+    return versionados.length >= 2 ? versionados[versionados.length - 2] : null;
+}
+
+function atualizarRotuloValidacao() {
+    const label = document.getElementById('testingSectionLabel');
+    if (!label) return;
+
+    const env = ambienteDeValidacao();
+    if (env) {
+        label.textContent = `Versões em validação (${KIND_LABELS[env.kind] || env.kind})`;
+        return;
+    }
+    // Esteira sem degrau de validação (ex.: dev → prod) ou nenhum app selecionado: rótulo
+    // genérico, em vez de prometer um ambiente que não existe.
+    label.textContent = 'Versões em validação';
+}
 
 async function loadPrTablesData(animate = false, expectedRevision = tenantOperations.snapshot()) {
-    const prResult = await API.fetchPRs(showOnlyInFlight);
+    // Busca sempre a lista completa e aplica o "em voo" no cliente, usando o pr.inFlight que a
+    // própria API calcula. Dois ganhos: os PRs que chegam dentro de um lote continuam tendo de
+    // onde herdar a esteira mesmo depois de entregues, e alternar o filtro deixa de ir na rede.
+    const prResult = await API.fetchPRs(false);
     if (!tenantOperations.isCurrent(expectedRevision)) return false;
     if (!prResult || !Array.isArray(prResult.prs)) {
         throw new Error('Falha ao carregar PRs');
@@ -953,6 +1092,14 @@ async function loadPrTablesData(animate = false, expectedRevision = tenantOperat
     currentData.batches = appFilter
         ? batches.filter(b => b.appId === currentAppId)
         : batches;
+    const appIds = [...new Set([
+        ...currentData.prs.map(pr => pr.appId),
+        ...currentData.batches.map(batch => batch.appId),
+    ].filter(Boolean))];
+    await Promise.all(appIds.map(appId => carregarEsteira(appId).catch(error => {
+        console.error(`Erro ao carregar a esteira do app ${appId}:`, error);
+        return [];
+    })));
     refreshOpenPrs(animate);
     refreshApprovedPrs(animate);
     return true;
@@ -961,10 +1108,55 @@ async function loadPrTablesData(animate = false, expectedRevision = tenantOperat
 function refreshTestingAndHistory(animate = false) {
     if (!Array.isArray(currentData.sprints)) return;
 
-    const activeSprints = currentData.sprints.filter(s => s.isActive);
-    const inactiveSprints = currentData.sprints.filter(s => !s.isActive);
+    const batchEstaEmValidacao = batch => {
+        if (!esteirasPorApp.has(batch.appId)) return batch.status === 'Deployed';
+        const validationEnv = ambienteDeValidacaoDaEsteira(esteirasPorApp.get(batch.appId) || []);
+        // Cuidado: os dois DTOs usam "batchId" para coisas diferentes. No deployment é a chave
+        // numérica (VersionBatch.Id); no lote é o identificador em texto ("batch_638..."). Comparar
+        // os dois campos de mesmo nome nunca dá verdadeiro, e a seção ficava sempre vazia.
+        return validationEnv?.current?.batchId === batch.id;
+    };
+
+    const filtrarSprint = (sprint, isActive) => {
+        if (filtros.sprint && filtros.sprint !== '__sem__' && sprint.name !== filtros.sprint) return null;
+        if (filtros.sprint === '__sem__') return null;
+        const versionBatches = (sprint.versionBatches || []).map(batch => ({
+            ...batch,
+            pullRequests: aplicarFiltros((batch.pullRequests || []).map(pr => ({
+                ...pr,
+                sprint: pr.sprint || sprint.name,
+            }))),
+        })).filter(batch => {
+            if (batch.pullRequests.length === 0 && temFiltrosAtivos()) return false;
+            if (!isActive) return true;
+            return batchEstaEmValidacao(batch);
+        });
+        return { ...sprint, versionBatches };
+    };
+    const activeSprints = currentData.sprints.filter(s => s.isActive).map(s => filtrarSprint(s, true)).filter(Boolean);
+    const inactiveSprints = currentData.sprints.filter(s => !s.isActive).map(s => filtrarSprint(s, false)).filter(Boolean);
+    if (!filtros.sprint || filtros.sprint === '__sem__') {
+        const noSprintBatches = currentData.batches
+            .filter(batch => !batch.sprintId && batchEstaEmValidacao(batch))
+            .map(batch => ({
+                ...batch,
+                pullRequests: aplicarFiltros((batch.pullRequests || []).map(pr => ({ ...pr, sprint: '' }))),
+            }))
+            .filter(batch => batch.pullRequests.length > 0);
+        if (noSprintBatches.length > 0) {
+            activeSprints.push({ id: 'without-sprint', name: 'Sem sprint', canComplete: false, versionBatches: noSprintBatches });
+        }
+    }
     DOM.renderTestingTable(activeSprints, 'dashboardTesting', openEditModal, animate);
     DOM.renderHistoryTable(inactiveSprints, 'dashboardHistory', openEditModal, animate);
+    if (temFiltrosAtivos()) {
+        const hasTestingResults = activeSprints.some(sprint =>
+            (sprint.versionBatches || []).some(batch => batch.pullRequests.length > 0));
+        const hasHistoryResults = inactiveSprints.some(sprint =>
+            (sprint.versionBatches || []).some(batch => batch.pullRequests.length > 0));
+        if (!hasTestingResults) renderFilteredEmpty('dashboardTesting');
+        if (!hasHistoryResults) renderFilteredEmpty('dashboardHistory');
+    }
     if (window.lucide) window.lucide.createIcons();
     if (AuthService && AuthService.applyRoleBasedVisibility) AuthService.applyRoleBasedVisibility();
 }
@@ -992,9 +1184,11 @@ async function loadData(skipLoading = false, expectedRevision = tenantOperations
         }
         currentData.sprints = sprints;
         refreshTestingAndHistory(false);
+        setDashboardLoadError('');
     } catch (error) {
         if (!tenantOperations.isCurrent(expectedRevision)) return;
         console.error('Erro ao carregar dados:', error);
+        setDashboardLoadError('A API não respondeu. Os dados que já estavam na tela foram mantidos.');
         DOM.showToast('Erro ao carregar dados da API', 'error');
     } finally {
         if (!skipLoading && tenantOperations.isCurrent(expectedRevision)) {
@@ -1003,23 +1197,374 @@ async function loadData(skipLoading = false, expectedRevision = tenantOperations
     }
 }
 
+// ── Filtros da esteira (Épico 2, 3.4) ──────────────────────────────────────
+// App, status, ambiente e sprint. Aplicados no cliente sobre a lista já carregada; o único
+// filtro que vive na API é o "em voo", porque ele depende de presença e de deployment ativo
+// no último degrau, que o cliente não tem como calcular.
+
+const filtros = {
+    app: initialQuery.get('filterApp') || '',
+    status: initialQuery.get('status') || '',
+    environment: initialQuery.get('environment') || '',
+    sprint: initialQuery.get('sprint') || '',
+};
+
+function temFiltrosAtivos() {
+    return Object.values(filtros).some(Boolean);
+}
+
+function atualizarPainelFiltros() {
+    const label = document.getElementById('filterPanelLabel');
+    if (!label) return;
+    const total = Object.values(filtros).filter(Boolean).length;
+    label.textContent = total > 0 ? `Filtros (${total})` : 'Filtros';
+}
+
+function persistirFiltrosNaUrl() {
+    const query = new URLSearchParams(window.location.search);
+    const chaves = { app: 'filterApp', status: 'status', environment: 'environment', sprint: 'sprint' };
+    Object.entries(chaves).forEach(([campo, parametro]) => {
+        if (filtros[campo]) query.set(parametro, filtros[campo]);
+        else query.delete(parametro);
+    });
+    query.set('inFlight', String(showOnlyInFlight));
+    history.replaceState(null, '', `${window.location.pathname}?${query.toString()}`);
+    atualizarPainelFiltros();
+}
+
+function renderFilteredEmpty(containerId, tableBody = false) {
+    const container = document.getElementById(containerId);
+    if (!container) return;
+    const content = '<div class="empty-state"><span>Nenhum resultado para os filtros selecionados.</span><button class="btn btn-outline btn-sm clear-inline-filters" type="button">Limpar filtros</button></div>';
+    container.innerHTML = tableBody ? `<tr><td colspan="7">${content}</td></tr>` : content;
+    container.querySelector('.clear-inline-filters')?.addEventListener('click', limparFiltros);
+}
+
+async function limparFiltros() {
+    Object.keys(filtros).forEach(chave => { filtros[chave] = ''; });
+    ['filterApp', 'filterStatus', 'filterEnvironment', 'filterSprint'].forEach(id => {
+        const select = document.getElementById(id);
+        if (select) select.value = '';
+    });
+    await carregarEsteiraDoApp(currentAppId);
+    persistirFiltrosNaUrl();
+    refreshOpenPrs(true);
+    refreshApprovedPrs(true);
+    refreshTestingAndHistory(true);
+}
+
+function popularFiltroDeApp(apps) {
+    const select = document.getElementById('filterApp');
+    if (!select) return;
+
+    const anterior = filtros.app || select.value;
+    select.innerHTML = '<option value="">Todos</option>';
+    apps.forEach(app => {
+        const option = document.createElement('option');
+        option.value = app.id;
+        option.textContent = app.name;
+        select.appendChild(option);
+    });
+    select.value = anterior;
+
+    // Dentro de um app (?app=), a lista já está restrita — o filtro só confundiria.
+    const wrapper = select.closest('.esteira-filters__field');
+    if (wrapper) wrapper.style.display = appFilter ? 'none' : '';
+}
+
+function popularFiltroDeAmbiente() {
+    const select = document.getElementById('filterEnvironment');
+    if (!select) return;
+
+    const anterior = filtros.environment || select.value;
+    select.innerHTML = esteiraDoApp.length > 0
+        ? '<option value="">Todos</option>'
+        : '<option value="">Selecione um app primeiro</option>';
+    select.disabled = esteiraDoApp.length === 0;
+    esteiraDoApp.forEach(env => {
+        const option = document.createElement('option');
+        option.value = env.kind;
+        option.textContent = KIND_LABELS[env.kind] || env.kind;
+        select.appendChild(option);
+    });
+    select.value = anterior;
+
+    // Sem app selecionado não há uma esteira única: cada app tem a sua, e um filtro
+    // "dev/stg/prod" fixo seria exatamente o acoplamento que o épico removeu.
+    const wrapper = select.closest('.esteira-filters__field');
+    if (wrapper) wrapper.style.display = '';
+}
+
+function popularFiltroDeSprint() {
+    const select = document.getElementById('filterSprint');
+    if (!select) return;
+
+    const anterior = filtros.sprint || select.value;
+    const sprints = [...new Set(currentData.prs.map(p => p.sprint).filter(Boolean))].sort();
+    select.innerHTML = '<option value="">Todas</option><option value="__sem__">Sem sprint</option>';
+    sprints.forEach(nome => {
+        const option = document.createElement('option');
+        option.value = nome;
+        option.textContent = nome;
+        select.appendChild(option);
+    });
+    select.value = anterior;
+}
+
+function statusDoPr(pr) {
+    if (pr.needsCorrection) return 'ajustes';
+    if (pr.version || pr.versionBatchRefId) return 'versionado';
+    if (pr.approved) return 'aprovado';
+    return 'revisao';
+}
+
+function aplicarFiltros(prs) {
+    return prs.filter(pr => {
+        if (filtros.app && pr.appId !== filtros.app) return false;
+        if (filtros.status && statusDoPr(pr) !== filtros.status) return false;
+        if (filtros.sprint === '__sem__' && pr.sprint) return false;
+        if (filtros.sprint && filtros.sprint !== '__sem__' && pr.sprint !== filtros.sprint) return false;
+        if (filtros.environment) {
+            const slot = (pr.environments || []).find(e => e.kind === filtros.environment);
+            if (!slot?.present) return false;
+        }
+        return true;
+    });
+}
+
+function proximoAmbienteDoLote(batch) {
+    const esteira = esteirasPorApp.get(batch.appId) || [];
+    const versionados = esteira.filter(env => env.mode === 'Versioned');
+    if (versionados.length === 0) return null;
+
+    // Mesma armadilha de nome descrita em refreshTestingAndHistory: o "batchId" do deployment é
+    // a chave numérica (VersionBatch.Id) e o do lote é o texto "batch_638...". Comparar os dois
+    // campos homônimos nunca dá verdadeiro, então o índice do último ambiente implantado ficava
+    // em -1 e o "próximo" era sempre o primeiro degrau: o botão repetia "Implantar em Staging" e
+    // produção ficava inalcançável pelo Dashboard.
+    if (batch.isHotfix) {
+        const ultimo = versionados[versionados.length - 1];
+        if (ultimo.current?.batchId === batch.id) return null;
+        return { kind: ultimo.kind, label: KIND_LABELS[ultimo.kind] || ultimo.kind };
+    }
+
+    const ultimoIndiceImplantado = versionados.reduce((maior, env, indice) =>
+        env.current?.batchId === batch.id ? indice : maior, -1);
+    const proximo = versionados[ultimoIndiceImplantado + 1];
+    return proximo ? { kind: proximo.kind, label: KIND_LABELS[proximo.kind] || proximo.kind } : null;
+}
+
+['filterApp', 'filterStatus', 'filterEnvironment', 'filterSprint'].forEach(id => {
+    const select = document.getElementById(id);
+    if (!select) return;
+    select.addEventListener('change', async (event) => {
+        filtros[id.replace('filter', '').toLowerCase()] = event.target.value;
+        if (id === 'filterApp') {
+            filtros.environment = '';
+            await carregarEsteiraDoApp(filtros.app);
+        }
+        persistirFiltrosNaUrl();
+        refreshOpenPrs(true);
+        refreshApprovedPrs(true);
+        refreshTestingAndHistory(true);
+    });
+});
+
+const initialStatusFilter = document.getElementById('filterStatus');
+if (initialStatusFilter) initialStatusFilter.value = filtros.status;
+const initialInFlightToggle = document.getElementById('inFlightToggle');
+if (initialInFlightToggle) initialInFlightToggle.checked = showOnlyInFlight;
+const filterPanel = document.getElementById('filterPanel');
+if (filterPanel && window.matchMedia('(max-width: 640px)').matches) filterPanel.removeAttribute('open');
+atualizarPainelFiltros();
+
+const filterClearBtn = document.getElementById('filterClearBtn');
+if (filterClearBtn) {
+    filterClearBtn.addEventListener('click', limparFiltros);
+}
+
+// ── Vínculos genéricos do PR (Épico 2, 2.8) ────────────────────────────────
+// Substituem, na prática, os três campos fixos (Link PR / Link Task / Post Teams): aqui
+// cabe qualquer tipo, sem limite, e cada item é removível. Os campos antigos seguem no
+// formulário até a migração de dados que os remove, fora do escopo deste épico.
+
+const LINK_KIND_LABELS = {
+    Task: 'Task',
+    Pr: 'Pull Request',
+    Communication: 'Comunicação',
+    Pipeline: 'Pipeline',
+    Other: 'Outro',
+};
+
+let prLinksPr = null;
+let draftPrLinks = [];
+
+function renderPrLinks(links) {
+    const lista = document.getElementById('prLinksList');
+    if (!lista) return;
+
+    lista.innerHTML = '';
+    if (!links || links.length === 0) {
+        const vazio = document.createElement('li');
+        vazio.className = 'pipeline-empty';
+        vazio.textContent = 'Nenhum vínculo.';
+        lista.appendChild(vazio);
+        return;
+    }
+
+    links.forEach(link => {
+        const item = document.createElement('li');
+        item.className = 'link-item';
+
+        const kind = document.createElement('span');
+        kind.className = 'link-item__kind';
+        kind.textContent = LINK_KIND_LABELS[link.kind] || link.kind;
+
+        // textContent, nunca innerHTML: a URL vem da API e pode ter sido digitada por qualquer um.
+        const anchor = document.createElement('a');
+        anchor.className = 'link-item__url';
+        anchor.href = link.url;
+        anchor.target = '_blank';
+        anchor.rel = 'noopener noreferrer';
+        anchor.textContent = link.label || link.url;
+        anchor.title = link.url;
+
+        const remover = document.createElement('button');
+        remover.type = 'button';
+        remover.className = 'btn btn-outline btn-sm';
+        remover.textContent = 'Remover';
+        remover.addEventListener('click', async () => {
+            if (!prLinksPr) {
+                draftPrLinks = draftPrLinks.filter(item => item.clientId !== link.clientId);
+                renderPrLinks(draftPrLinks);
+                return;
+            }
+
+            remover.disabled = true;
+            try {
+                await API.removePrLink(prLinksPr.appId, prLinksPr.id, link.id);
+                prLinksPr.links = (prLinksPr.links || []).filter(l => l.id !== link.id);
+                renderPrLinks(prLinksPr.links);
+                DOM.showToast('Vínculo removido.', 'success');
+            } catch (error) {
+                remover.disabled = false;
+                DOM.showToast(error?.message || 'Não foi possível remover o vínculo.', 'error');
+            }
+        });
+
+        item.append(kind, anchor, remover);
+        lista.appendChild(item);
+    });
+}
+
+const prLinkAddBtn = document.getElementById('prLinkAddBtn');
+if (prLinkAddBtn) {
+    prLinkAddBtn.addEventListener('click', async () => {
+        const urlInput = document.getElementById('prLinkUrl');
+        const labelInput = document.getElementById('prLinkLabel');
+        const erro = document.getElementById('prLinkUrlError');
+        const url = urlInput.value.trim();
+
+        const limparErro = () => {
+            urlInput.classList.remove('is-invalid');
+            erro.textContent = '';
+            erro.classList.remove('visible');
+        };
+        const marcarErro = (mensagem) => {
+            urlInput.classList.add('is-invalid');
+            erro.textContent = mensagem;
+            erro.classList.add('visible'); // .field-error nasce display:none
+        };
+
+        if (!url) return marcarErro('Informe o endereço do vínculo.');
+        if (url.length > 1000) return marcarErro('O endereço passa de 1000 caracteres.');
+        if (!Form.isOptionalUrl(url)) return marcarErro('Informe um endereço HTTP ou HTTPS válido.');
+        limparErro();
+
+        const novoVinculo = {
+            kind: document.getElementById('prLinkKind').value,
+            url,
+            label: labelInput.value.trim() || null,
+        };
+
+        if (!prLinksPr) {
+            draftPrLinks = [...draftPrLinks, { ...novoVinculo, clientId: crypto.randomUUID() }];
+            renderPrLinks(draftPrLinks);
+            urlInput.value = '';
+            labelInput.value = '';
+            return;
+        }
+
+        try {
+            const criado = await API.addPrLink(prLinksPr.appId, prLinksPr.id, novoVinculo);
+            prLinksPr.links = [...(prLinksPr.links || []), criado];
+            renderPrLinks(prLinksPr.links);
+            urlInput.value = '';
+            labelInput.value = '';
+            DOM.showToast('Vínculo adicionado.', 'success');
+        } catch (error) {
+            marcarErro(error?.message || 'Não foi possível adicionar o vínculo.');
+        }
+    });
+
+    document.getElementById('prLinkUrl').addEventListener('input', () => {
+        document.getElementById('prLinkUrl').classList.remove('is-invalid');
+        const erro = document.getElementById('prLinkUrlError');
+        erro.textContent = '';
+        erro.classList.remove('visible');
+    });
+}
+
+const emVoo = pr => !showOnlyInFlight || pr.inFlight !== false;
+
 function refreshOpenPrs(animate = false) {
-    const openPrs = currentData.prs.filter(p => !p.approved);
+    popularFiltroDeSprint();
+    // "em voo" agora é filtro de cliente sobre o pr.inFlight que a API já devolve.
+    const openPrs = aplicarFiltros(currentData.prs.filter(p => !p.approved && emVoo(p)));
     const totalOpenBadge = document.getElementById('totalOpenPrs');
     if (totalOpenBadge) {
         totalOpenBadge.textContent = openPrs.length;
         totalOpenBadge.style.display = openPrs.length > 0 ? 'inline-block' : 'none';
     }
     DOM.renderOpenTable(openPrs, 'openPrTableBody', openEditModal, animate);
+    if (temFiltrosAtivos() && openPrs.length === 0) renderFilteredEmpty('openPrTableBody', true);
     if (window.lucide) window.lucide.createIcons();
     if (AuthService && AuthService.applyRoleBasedVisibility) AuthService.applyRoleBasedVisibility();
+}
+
+// Espelha a regra do card de backlog em renderApprovedTables: aprovado, ainda não entregue, em
+// voo, dentro dos filtros ativos e fora de qualquer lote. Casa por appId, e não pelo nome exibido,
+// porque é o appId que o backend usa para montar o lote.
+function prsElegiveisParaCorte(appId) {
+    const idsEmLote = new Set((currentData.batches || [])
+        .flatMap(batch => (batch.pullRequests || []).map(pr => pr.id)));
+    return aplicarFiltros((currentData.prs || []).filter(pr =>
+        pr.appId === appId && pr.approved && !pr.deployedToStg && emVoo(pr) && !idsEmLote.has(pr.id)));
 }
 
 function refreshApprovedPrs(animate = false) {
     if (!Array.isArray(currentData.batches)) return;
 
-    const approvedPending = currentData.prs.filter(p => p.approved && !p.deployedToStg);
-    DOM.renderApprovedTables(approvedPending, currentData.batches, 'dashboardApproved', openEditModal, animate);
+    const approvedPending = aplicarFiltros(currentData.prs.filter(p => p.approved && !p.deployedToStg && emVoo(p)));
+
+    // Os PRs que vêm dentro do lote são serializados pelo VersionBatchService e não passam
+    // pelo enriquecimento da esteira, então chegam sem `environments` — a coluna Esteira
+    // exibia "Sem esteira configurada" para todos. Reaproveita o PR já enriquecido da lista.
+    const prsEnriquecidos = new Map(currentData.prs.map(pr => [pr.id, pr]));
+    const comEsteira = pr => {
+        const enriquecido = prsEnriquecidos.get(pr.id);
+        return enriquecido ? { ...pr, environments: enriquecido.environments, links: enriquecido.links } : pr;
+    };
+
+    const batches = currentData.batches.map(batch => ({
+        ...batch,
+        deploymentTarget: proximoAmbienteDoLote(batch),
+        pullRequests: aplicarFiltros((batch.pullRequests || []).map(comEsteira)),
+    })).filter(batch => batch.pullRequests.length > 0 || !temFiltrosAtivos());
+    DOM.renderApprovedTables(approvedPending, batches, 'dashboardApproved', openEditModal, animate);
+    if (temFiltrosAtivos() && approvedPending.length === 0 && batches.length === 0) {
+        renderFilteredEmpty('dashboardApproved');
+    }
     if (window.lucide) window.lucide.createIcons();
     if (AuthService && AuthService.applyRoleBasedVisibility) AuthService.applyRoleBasedVisibility();
 }
@@ -1032,39 +1577,19 @@ function openEditModal(pr) {
     document.getElementById('project').value = pr.project || '';
     document.getElementById('dev').value = resolveDeveloperId(availableUsers, pr.devId, pr.dev);
     document.getElementById('summary').value = pr.summary || '';
-    document.getElementById('prLink').value = pr.prLink || '';
-    document.getElementById('taskLink').value = pr.taskLink || '';
-    document.getElementById('teamsLink').value = pr.teamsLink || '';
-    
-    updateSummaryLabel(pr.taskLink || '');
-
-    const relatedContainer = document.getElementById('relatedTasksContainer');
-    relatedContainer.innerHTML = '';
-    
-    if (pr.linksRelatedTask) {
-        const links = pr.linksRelatedTask.split(';').filter(link => link.trim() !== '');
-        links.forEach(linkData => {
-            let [summary, url] = linkData.split('|');
-            if (!url) {
-                url = summary;
-                summary = '';
-            }
-            addRelatedTaskInput(url, summary);
-        });
-    }
-    
-    updateSummaryLabel();
 
     const noTestingCheckbox = document.getElementById('noTestingRequired');
     if (noTestingCheckbox) {
         noTestingCheckbox.checked = !!pr.noTestingRequired;
     }
 
-    const appUser = LocalStorage.getItem('appUser');
     const isApproved = !!pr.approved;
 
+    prLinksPr = pr;
+    draftPrLinks = [];
+    renderPrLinks(pr.links || []);
 
-    const fieldsToLock = ['project', 'dev', 'summary', 'prLink', 'taskLink', 'teamsLink'];
+    const fieldsToLock = ['project', 'dev', 'summary'];
     fieldsToLock.forEach(id => {
         document.getElementById(id).disabled = isApproved;
     });
@@ -1075,22 +1600,13 @@ function openEditModal(pr) {
         noTestingCheckbox.disabled = isApproved;
     }
 
-    const relatedInputs = document.querySelectorAll('.related-task-input');
-    relatedInputs.forEach(input => input.disabled = isApproved);
-    
-    const addRelatedBtn = document.getElementById('addRelatedTaskBtn');
-    if (addRelatedBtn) addRelatedBtn.disabled = isApproved;
-    
-    const removeRelatedBtns = document.querySelectorAll('#relatedTasksContainer button');
-    removeRelatedBtns.forEach(btn => btn.disabled = isApproved);
-
     if (isApproved) {
         document.getElementById('modalTitle').innerHTML = 'Editar Pull Request <span class="tag" style="background: color-mix(in srgb, var(--success-color) 16%, transparent); color: var(--success-color); margin-left:10px;">Aprovado</span>';
     } else {
         document.getElementById('modalTitle').textContent = 'Editar Pull Request';
     }
 
-    prModal.style.display = 'flex';
+    openAccessibleModal(prModal, prModal.querySelector('select:not(:disabled), input:not([type="hidden"]):not(:disabled), textarea:not(:disabled)'));
 }
 
 function openAddModal() {
@@ -1106,9 +1622,9 @@ function openAddModal() {
     Form.resetFormState(prForm);
     document.getElementById('prId').value = '';
     
-    updateSummaryLabel();
-    
-    document.getElementById('relatedTasksContainer').innerHTML = '';
+    prLinksPr = null;
+    draftPrLinks = [];
+    renderPrLinks(draftPrLinks);
 
     const currentMe = AuthService.getMe();
     document.getElementById('dev').value = resolveDeveloperId(
@@ -1117,7 +1633,7 @@ function openAddModal() {
         currentMe?.name || LocalStorage.getItem('appUser')
     );
 
-    const fieldsToLock = ['project', 'dev', 'summary', 'prLink', 'taskLink', 'teamsLink'];
+    const fieldsToLock = ['project', 'dev', 'summary'];
     fieldsToLock.forEach(id => {
         document.getElementById(id).disabled = false;
     });
@@ -1135,11 +1651,8 @@ function openAddModal() {
         noTestingCheckbox.disabled = false;
     }
 
-    const addRelatedBtn = document.getElementById('addRelatedTaskBtn');
-    if (addRelatedBtn) addRelatedBtn.disabled = false;
-
     if (!tenantOperations.isCurrent(openingRevision) || tenantOperations.isTransitioning()) return;
-    prModal.style.display = 'flex';
+    openAccessibleModal(prModal, prModal.querySelector('select:not(:disabled), input:not([type="hidden"]):not(:disabled), textarea:not(:disabled)'));
 }
 
 document.getElementById('addPrBtn').addEventListener('click', openAddModal);
@@ -1150,12 +1663,10 @@ const inFlightToggle = document.getElementById('inFlightToggle');
 if (inFlightToggle) {
     inFlightToggle.addEventListener('change', async (event) => {
         showOnlyInFlight = event.target.checked;
-        try {
-            await loadPrTablesData(true);
-        } catch (error) {
-            console.error('Erro ao alternar o filtro de PRs em voo:', error);
-            DOM.showToast('Não foi possível recarregar a lista de PRs.', 'error');
-        }
+        persistirFiltrosNaUrl();
+        // A lista completa já está em memória: alternar é só re-renderizar.
+        refreshOpenPrs(true);
+        refreshApprovedPrs(true);
     });
 }
 
@@ -1216,7 +1727,7 @@ if (projectHelpBtn && projectHelpTooltip) {
     });
 }
 
-document.getElementById('addRelatedTaskBtn').addEventListener('click', () => addRelatedTaskInput());
+document.getElementById('addRelatedTaskBtn')?.addEventListener('click', () => addRelatedTaskInput());
 
 const taskLinkInput = document.getElementById('taskLink');
 if (taskLinkInput) {
@@ -1231,7 +1742,7 @@ function updateSummaryLabel() {
     
     if (!primaryTagsContainer || !relatedTagsContainer) return;
 
-    const mainUrl = document.getElementById('taskLink').value;
+    const mainUrl = document.getElementById('taskLink')?.value || '';
     const primaryId = extractJiraId(mainUrl);
 
     if (primaryId) {
@@ -1337,7 +1848,7 @@ document.getElementById('newSprintBtn').addEventListener('click', () => {
     if (newSprintNameInput) newSprintNameInput.value = '';
     sprintDateRangePicker.reset();
     clearNewSprintValidation();
-    if (newSprintModal) newSprintModal.style.display = 'flex';
+    openAccessibleModal(newSprintModal, newSprintNameInput);
 });
 
 newSprintNameInput?.addEventListener('input', () => {
@@ -1423,7 +1934,7 @@ window.approvePr = async (prId) => {
         }
     } catch (error) {
         console.error('Erro ao aprovar:', error);
-        DOM.showToast('Erro ao aprovar: ' + error.message, 'error');
+        DOM.showToast(`Não foi possível aprovar. ${error.message}`, 'error');
     }
 };
 
@@ -1569,7 +2080,7 @@ function openSetupModal() {
     }).catch(err => {
         console.error('Erro ao buscar config:', err);
     }).finally(() => {
-        if (setupModal) setupModal.style.display = 'flex';
+        openAccessibleModal(setupModal);
     });
 }
 
@@ -1629,33 +2140,45 @@ prForm.addEventListener('submit', async (e) => {
             project: document.getElementById('project').value,
             devId: selectedDeveloper.id,
             summary: document.getElementById('summary').value,
-            prLink: document.getElementById('prLink').value || '',
-            taskLink: document.getElementById('taskLink').value || '',
-            teamsLink: document.getElementById('teamsLink').value || '',
+            prLink: '',
+            taskLink: null,
+            teamsLink: null,
             noTestingRequired: document.getElementById('noTestingRequired').checked,
-            linksRelatedTask: Array.from(document.querySelectorAll('.related-task-group'))
-                .map(group => {
-                    const url = group.querySelector('.related-task-input-url').value.trim();
-                    const summary = group.querySelector('.related-task-input-summary').value.trim();
-                    return url ? `${summary}|${url}` : '';
-                })
-                .filter(val => val !== '')
-                .join(';')
+            linksRelatedTask: ''
         };
 
         const successMessage = prIdInput
             ? 'PR atualizado com sucesso!'
             : 'PR criado com sucesso!';
 
+        let linkFailures = 0;
         if (prIdInput) {
             await API.updatePR(prIdInput, prData);
         } else {
-            await API.createPR(prData);
+            const createdPr = await API.createPR(prData);
+            const linksToCreate = [...draftPrLinks];
+            for (const link of linksToCreate) {
+                try {
+                    await API.addPrLink(createdPr.appId, createdPr.id, {
+                        kind: link.kind,
+                        url: link.url,
+                        label: link.label,
+                    });
+                } catch (linkError) {
+                    linkFailures += 1;
+                    console.error('PR criado, mas um vínculo não pôde ser salvo:', linkError);
+                }
+            }
         }
 
         prModal.style.display = 'none';
         prForm.reset();
-        DOM.showToast(successMessage);
+        DOM.showToast(
+            linkFailures > 0
+                ? `PR criado, mas ${linkFailures} vínculo(s) não puderam ser salvo(s). Adicione-os ao editar o PR.`
+                : successMessage,
+            linkFailures > 0 ? 'warning' : 'success'
+        );
 
         try {
             await loadPrTablesData(true);
@@ -1722,7 +2245,12 @@ window.saveGroupVersion = async (batchId) => {
         return;
     }
 
-    if (confirm(`Aplicar versão ${version} para este lote?`)) {
+    const confirmado = await DOM.confirmDialog(
+        `A versão ${version} será aplicada a todos os PRs deste lote.`,
+        `Aplicar a versão ${version}?`,
+        { confirmLabel: 'Aplicar versão' },
+    );
+    if (confirmado) {
         try {
             DOM.showLoading(true);
             
@@ -1745,10 +2273,28 @@ window.saveGroupVersion = async (batchId) => {
     }
 };
 
-window.requestVersionBatch = async (prIds, projectName) => {
+// A lista de PRs do corte é resolvida NO CLIQUE, não na renderização, e sobre dados recarregados:
+// cortar em cima do retrato antigo da tela deixava PR aprovado de fora do lote sem aviso nenhum.
+window.requestVersionBatch = async (appId, projectName) => {
     if (!projectName) projectName = 'este projeto';
-    
-    console.log('Solicitando versão para IDs:', prIds);
+
+    try {
+        DOM.showLoading(true);
+        await loadPrTablesData(true);
+    } catch (error) {
+        console.error('Não foi possível atualizar os PRs antes do corte:', error);
+        DOM.showToast('Não foi possível atualizar a lista de PRs. Tente de novo.', 'error');
+        return;
+    } finally {
+        DOM.showLoading(false);
+    }
+
+    const prIds = prsElegiveisParaCorte(appId).map(pr => pr.id);
+    if (prIds.length === 0) {
+        DOM.showToast('Nenhum PR aprovado disponível para cortar versão neste app.', 'warning');
+        return;
+    }
+
     openRequestVersionModal(prIds, projectName);
 };
 
@@ -1769,30 +2315,74 @@ window.fetchBatches = async () => {
     }
 };
 
-window.confirmDeploy = async (batchId) => {
-    const hasActiveSprint = currentData.sprints && currentData.sprints.some(s => s.isActive);
-    if (!hasActiveSprint) {
-        DOM.showToast('Não há uma Sprint ativa. Crie uma Sprint antes de liberar para STG.', 'warning');
-        return;
-    }
-
-    if (confirm(`Confirmar liberação deste lote para ambiente de Teste (STG)?`)) {
+window.confirmDeploy = async (batchId, appId, targetKind, targetLabel) => {
+    const confirmed = await DOM.confirmDialog(
+        `Fazer deploy desta versão em ${targetLabel}? A composição do lote ficará congelada no primeiro deploy.`,
+        `Deploy ${targetLabel}`,
+        { confirmLabel: 'Deploy' },
+    );
+    if (confirmed) {
         try {
             DOM.showLoading(true);
-            await API.releaseBatchToStaging(batchId);
-            DOM.showToast('Versão liberada para Teste (STG) com sucesso!');
+            await API.deployToEnvironment(appId, String(targetKind).toLowerCase(), batchId);
+            esteirasPorApp.delete(appId);
+            if (appId === currentAppId || appId === filtros.app) await carregarEsteiraDoApp(appId);
+            DOM.showToast(`Versão implantada em ${targetLabel}.`);
             await loadData(true);
         } catch (error) {
-            console.error('Erro ao liberar lote:', error);
-            DOM.showToast('Erro ao liberar lote: ' + error.message, 'error');
+            console.error('Erro ao implantar lote:', error);
+            DOM.showToast('Erro ao implantar lote: ' + error.message, 'error');
         } finally {
             DOM.showLoading(false);
         }
     }
 };
 
+window.markBatchHotfix = (batchId) => {
+    pendingHotfixBatchId = batchId;
+    hotfixReasonInput.value = '';
+    document.getElementById('hotfixReasonError')?.classList.remove('visible');
+    openAccessibleModal(hotfixModal, hotfixReasonInput);
+};
+
+document.getElementById('hotfixCancelBtn')?.addEventListener('click', () => {
+    pendingHotfixBatchId = null;
+    closeAllModals();
+});
+
+document.getElementById('hotfixConfirmBtn')?.addEventListener('click', async () => {
+    const reason = hotfixReasonInput.value.trim();
+    const errorElement = document.getElementById('hotfixReasonError');
+    if (!reason) {
+        errorElement.textContent = 'Informe a justificativa do hotfix.';
+        errorElement.classList.add('visible');
+        hotfixReasonInput.focus();
+        return;
+    }
+
+    const button = document.getElementById('hotfixConfirmBtn');
+    button.disabled = true;
+    try {
+        await API.markBatchAsHotfix(pendingHotfixBatchId, reason);
+        pendingHotfixBatchId = null;
+        hotfixModal.style.display = 'none';
+        DOM.showToast('Versão marcada como hotfix. A justificativa foi registrada.');
+        await loadData(true);
+    } catch (error) {
+        errorElement.textContent = error?.message || 'Não foi possível marcar o hotfix.';
+        errorElement.classList.add('visible');
+    } finally {
+        button.disabled = false;
+    }
+});
+
 window.removeVersionFromBatch = async (batchId) => {
-    if (confirm(`ATENÇÃO: Deseja remover as informações de versão deste lote? \nIsso fará com que os PRs voltem para o status 'Aguardando Versão'.`)) {
+    const confirmado = await DOM.confirmDialog(
+        'Os PRs voltarão para o status "Aguardando Versão".',
+        'Remover as informações de versão?',
+        { confirmLabel: 'Remover versão', danger: true },
+    );
+    if (confirmado) {
         try {
             DOM.showLoading(true);
             await API.removeVersionFromBatch(batchId);
@@ -1808,7 +2398,12 @@ window.removeVersionFromBatch = async (batchId) => {
 };
 
 window.removePrFromBatch = async (batchId, prId) => {
-    if (confirm(`DESEJA REMOVER ESSE PR DO LOTE?\nEle voltará para o status de 'Aprovado' e sairá desta versão.`)) {
+    const confirmado = await DOM.confirmDialog(
+        'O PR voltará para o status "Aprovado" e sairá desta versão.',
+        'Remover este PR do lote?',
+        { confirmLabel: 'Remover do lote', danger: true },
+    );
+    if (confirmado) {
         try {
             DOM.showLoading(true);
             await API.removePrFromBatch(batchId, prId);
@@ -1826,7 +2421,12 @@ window.removePrFromBatch = async (batchId, prId) => {
 window.cancelVersionRequestByPrIds = async (prIds) => {
     if (!prIds || !prIds.length) return;
     
-    if (confirm(`Deseja CANCELAR a solicitação de versão para estes ${prIds.length} PRs? \nEles voltarão para a lista de 'Aprovados'.`)) {
+    const confirmado = await DOM.confirmDialog(
+        `Os ${prIds.length} PRs voltarão para a lista de "Aprovados" e o lote será removido.`,
+        'Cancelar a solicitação de versão?',
+        { confirmLabel: 'Cancelar solicitação', danger: true },
+    );
+    if (confirmado) {
         try {
             DOM.showLoading(true);
             await API.cancelVersionRequestByPrIds(prIds);
@@ -1842,7 +2442,12 @@ window.cancelVersionRequestByPrIds = async (prIds) => {
 };
 
 window.cancelVersionRequest = async (batchId) => {
-    if (confirm(`Deseja CANCELAR a solicitação de versão? \nOs PRs voltarão para a lista de 'Aprovados' e sairão deste lote.`)) {
+    const confirmado = await DOM.confirmDialog(
+        'Os PRs voltarão para a lista de "Aprovados" e o lote será removido.',
+        'Cancelar a solicitação de versão?',
+        { confirmLabel: 'Cancelar solicitação', danger: true },
+    );
+    if (confirmado) {
         try {
             DOM.showLoading(true);
             await API.cancelVersionRequest(batchId);
@@ -1858,7 +2463,12 @@ window.cancelVersionRequest = async (batchId) => {
 };
 
 window.deleteBatch = async (batchId) => {
-    if (confirm(`ATENÇÃO: Deseja DELETAR este lote completamente?\nTodos os PRs voltarão para o status 'Aprovado' e o lote será removido.`)) {
+    const confirmado = await DOM.confirmDialog(
+        'Todos os PRs voltarão para o status "Aprovado" e o lote será removido.',
+        'Deletar este lote?',
+        { confirmLabel: 'Deletar lote', danger: true },
+    );
+    if (confirmado) {
         try {
             DOM.showLoading(true);
             await API.deleteBatch(batchId);
@@ -1891,7 +2501,12 @@ function showErrorModal(friendlyMsg, error) {
 }
 
 window.createGitLabIssue = async (batchId) => {
-    if (confirm(`Criar issue de deploy no GitLab para esse lote de versão?`)) {
+    const confirmado = await DOM.confirmDialog(
+        'Uma issue de deploy será aberta no GitLab para este lote.',
+        'Criar issue no GitLab?',
+        { confirmLabel: 'Criar issue' },
+    );
+    if (confirmado) {
         try {
             DOM.showLoading(true);
             await GitLabService.createIssue(batchId);

--- a/src/style.css
+++ b/src/style.css
@@ -2219,6 +2219,178 @@ body {
   animation: modalScaleIn 0.3s cubic-bezier(0.16, 1, 0.3, 1) forwards;
 }
 
+.pipeline-matrix {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  flex-wrap: nowrap;
+}
+
+.pipeline-step {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.15rem 0.45rem;
+  border-radius: var(--bs-border-radius-sm);
+  border: 1px solid var(--border-color);
+  font-size: 0.72rem;
+  font-weight: 600;
+  line-height: 1.4;
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+
+.pipeline-step--absent {
+  background: transparent;
+  color: var(--text-secondary);
+  border-style: dashed;
+  opacity: 0.75;
+}
+
+.pipeline-step--dev {
+  background: var(--module-tag-dev-bg);
+  color: var(--module-tag-dev-color);
+  border-color: transparent;
+}
+
+.pipeline-step--stg {
+  background: var(--module-tag-stg-bg);
+  color: var(--module-tag-stg-color);
+  border-color: transparent;
+}
+
+.pipeline-step--prod {
+  background: var(--module-tag-prod-bg);
+  color: var(--module-tag-prod-color);
+  border-color: transparent;
+}
+
+.pipeline-arrow {
+  color: var(--text-secondary);
+  opacity: 0.5;
+  font-size: 0.7rem;
+  user-select: none;
+}
+
+.pipeline-empty {
+  color: var(--text-secondary);
+  font-size: 0.75rem;
+}
+
+.entrega-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+  gap: 1.5rem;
+  align-items: start;
+}
+
+@media (max-width: 900px) {
+  .entrega-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+.entrega-panel {
+  background: var(--card-bg);
+  border: 1px solid var(--border-color);
+  border-radius: var(--bs-border-radius);
+  padding: 1.25rem;
+}
+
+.entrega-panel + .entrega-panel {
+  margin-top: 1.5rem;
+}
+
+.entrega-panel__title {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0 0 1rem;
+}
+
+.entrega-meta {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 0.5rem 1rem;
+  font-size: 0.85rem;
+}
+
+.entrega-meta dt {
+  color: var(--text-secondary);
+  font-weight: 500;
+}
+
+.entrega-meta dd {
+  margin: 0;
+  color: var(--text-primary);
+  overflow-wrap: anywhere;
+}
+
+.link-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.link-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.65rem;
+  border: 1px solid var(--border-color);
+  border-radius: var(--bs-border-radius-sm);
+  background: var(--bg-color);
+}
+
+.link-item__kind {
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-secondary);
+  font-weight: 600;
+  flex-shrink: 0;
+}
+
+.link-item__url {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--accent-color);
+}
+
+.pipeline-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.pipeline-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr) auto;
+  gap: 0.75rem;
+  align-items: center;
+  padding: 0.75rem;
+  border: 1px solid var(--border-color);
+  border-radius: var(--bs-border-radius-sm);
+  background: var(--card-bg);
+}
+
+@media (max-width: 768px) {
+  .pipeline-row {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+.pipeline-row__order {
+  font-variant-numeric: tabular-nums;
+  color: var(--text-secondary);
+  font-weight: 600;
+  font-size: 0.8rem;
+}
+
 * {
   margin: 0;
   padding: 0;

--- a/src/style.css
+++ b/src/style.css
@@ -2219,6 +2219,102 @@ body {
   animation: modalScaleIn 0.3s cubic-bezier(0.16, 1, 0.3, 1) forwards;
 }
 
+.esteira-filters {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.filter-panel > summary {
+  display: none;
+}
+
+.filter-panel:not([open]) > .esteira-filters {
+  display: flex;
+}
+
+.esteira-filters__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  min-width: 9rem;
+  flex: 1 1 9rem;
+}
+
+.esteira-filters__field label {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-secondary);
+  font-weight: 600;
+}
+
+@media (max-width: 640px) {
+  .filter-panel {
+    margin-bottom: 1rem;
+    border: 1px solid var(--border-color);
+    border-radius: var(--bs-border-radius);
+    background: var(--card-bg);
+  }
+  .filter-panel > summary {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.65rem 0.75rem;
+    color: var(--text-primary);
+    font-weight: 600;
+    cursor: pointer;
+  }
+  .filter-panel:not([open]) > .esteira-filters {
+    display: none;
+  }
+  .filter-panel .esteira-filters {
+    padding: 0 0.75rem 0.75rem;
+    margin-bottom: 0;
+  }
+  .esteira-filters__field {
+    flex-basis: 100%;
+  }
+}
+@media (max-width: 860px) {
+  .dashboard-header {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 1rem;
+  }
+  .dashboard-header .actions {
+    flex-wrap: wrap;
+    width: 100%;
+  }
+}
+@media (max-width: 420px) {
+  .container {
+    padding: 1rem;
+  }
+  .dashboard-section-head {
+    flex-wrap: wrap;
+    gap: 0.75rem;
+  }
+  .dashboard-header .current-user-avatar {
+    width: 64px;
+    height: 64px;
+  }
+  #prModal .modal-content {
+    width: calc(100% - 1.5rem);
+    padding: 1rem;
+  }
+  #prModal .form-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+  #prModal .form-group.full-width {
+    grid-column: auto;
+  }
+  #prForm {
+    padding-right: 0.25rem;
+  }
+}
 .pipeline-matrix {
   display: flex;
   align-items: center;
@@ -2362,15 +2458,94 @@ body {
   color: var(--accent-color);
 }
 
+.pr-link-form {
+  display: grid;
+  grid-template-columns: minmax(8rem, 0.8fr) minmax(12rem, 2fr) minmax(8rem, 1fr) auto;
+  gap: 0.5rem;
+  align-items: end;
+  margin-top: 0.5rem;
+}
+
+.pr-links-title {
+  display: block;
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+.pr-link-form__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  min-width: 0;
+}
+
+.pr-link-form__field label {
+  color: var(--text-secondary);
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+@media (max-width: 768px) {
+  .pr-link-form {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  }
+  .pr-link-form__field--url {
+    grid-column: 1/-1;
+    grid-row: 1;
+  }
+}
+@media (max-width: 420px) {
+  .pr-link-form {
+    grid-template-columns: minmax(0, 1fr);
+  }
+  .pr-link-form__field--url {
+    grid-column: auto;
+    grid-row: auto;
+  }
+}
 .pipeline-editor {
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
 }
 
+.env-history__status {
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+  margin-bottom: 0.5rem;
+}
+
+.env-history__status--error {
+  color: var(--module-status-error-color);
+}
+
+.module-empty-state--compact {
+  padding: 0.75rem;
+}
+
+.module-empty-state--compact h4 {
+  margin-bottom: 0.25rem;
+}
+
+.module-empty-state--compact p {
+  margin: 0;
+}
+
+.pipeline-editor__header {
+  display: grid;
+  grid-template-columns: 7rem minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr) auto;
+  gap: 0.75rem;
+  padding: 0 0.75rem 0.5rem;
+  color: var(--text-secondary);
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
 .pipeline-row {
   display: grid;
-  grid-template-columns: auto minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr) auto;
+  grid-template-columns: 7rem minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr) auto;
   gap: 0.75rem;
   align-items: center;
   padding: 0.75rem;
@@ -2380,17 +2555,102 @@ body {
 }
 
 @media (max-width: 768px) {
+  .pipeline-editor__header {
+    display: none;
+  }
   .pipeline-row {
     grid-template-columns: minmax(0, 1fr);
   }
 }
 .pipeline-row__order {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
   font-variant-numeric: tabular-nums;
   color: var(--text-secondary);
   font-weight: 600;
   font-size: 0.8rem;
 }
 
+.pipeline-move-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem;
+}
+
+.pipeline-move-btn svg {
+  width: 0.9rem;
+  height: 0.9rem;
+}
+
+.batch-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.page-state,
+.empty-state {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  padding: 1.5rem;
+  margin-bottom: 1rem;
+  color: var(--text-secondary);
+  background: var(--card-bg);
+  border: 1px solid var(--border-color);
+  border-radius: var(--bs-border-radius);
+  text-align: center;
+}
+
+.page-state[hidden] {
+  display: none;
+}
+
+.page-state--error,
+.page-state--forbidden {
+  border-color: color-mix(in srgb, var(--danger-color) 35%, var(--border-color));
+}
+
+.page-state--loading svg {
+  animation: rotation 1s linear infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .page-state--loading svg {
+    animation-duration: 3s;
+  }
+}
+.page-state > div {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  text-align: left;
+}
+
+#envGrid .module-card {
+  height: auto;
+  min-height: 14rem;
+}
+
+@media (max-width: 420px) {
+  .env-page-header {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+  .env-page-header .actions {
+    align-self: flex-start;
+  }
+  #envGrid .module-card {
+    min-height: 0;
+  }
+}
 * {
   margin: 0;
   padding: 0;
@@ -3085,6 +3345,11 @@ tr:hover {
   min-height: 46px;
 }
 
+.login-cancel {
+  width: 100%;
+  margin-top: 0.75rem;
+}
+
 .login-card .form-group input {
   width: 100%;
   min-height: 46px;
@@ -3639,6 +3904,7 @@ footer {
 
 footer p {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   justify-content: center;
   gap: 8px;

--- a/src/styles/_esteira.scss
+++ b/src/styles/_esteira.scss
@@ -1,0 +1,191 @@
+// Esteira de entrega (Épico 2) — matriz de ambientes por PR, tela de detalhe e
+// configuração da esteira.
+//
+// Sem cor nova e sem escala nova: as cores por ambiente já existem
+// (--module-tag-dev/stg/prod-*), o resto sai dos tokens de superfície e da escala
+// do Bootstrap 5.3.8, que é a escala oficial do projeto enquanto não houver tokens
+// próprios de espaçamento e raio.
+
+.pipeline-matrix {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    flex-wrap: nowrap;
+}
+
+// Um degrau da esteira. Ausente e presente se distinguem por preenchimento e opacidade,
+// nunca só por cor — daltônico e monitor ruim precisam ler a mesma coisa.
+.pipeline-step {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.15rem 0.45rem;
+    border-radius: var(--bs-border-radius-sm);
+    border: 1px solid var(--border-color);
+    font-size: 0.72rem;
+    font-weight: 600;
+    line-height: 1.4;
+    white-space: nowrap;
+    font-variant-numeric: tabular-nums;
+}
+
+.pipeline-step--absent {
+    background: transparent;
+    color: var(--text-secondary);
+    border-style: dashed;
+    opacity: 0.75;
+}
+
+.pipeline-step--dev {
+    background: var(--module-tag-dev-bg);
+    color: var(--module-tag-dev-color);
+    border-color: transparent;
+}
+
+.pipeline-step--stg {
+    background: var(--module-tag-stg-bg);
+    color: var(--module-tag-stg-color);
+    border-color: transparent;
+}
+
+.pipeline-step--prod {
+    background: var(--module-tag-prod-bg);
+    color: var(--module-tag-prod-color);
+    border-color: transparent;
+}
+
+// Separador entre degraus: a esteira é uma sequência, e a seta é o que carrega
+// essa informação. Decorativo para leitor de tela.
+.pipeline-arrow {
+    color: var(--text-secondary);
+    opacity: 0.5;
+    font-size: 0.7rem;
+    user-select: none;
+}
+
+.pipeline-empty {
+    color: var(--text-secondary);
+    font-size: 0.75rem;
+}
+
+// ── Tela de detalhe da entrega ──────────────────────────────────────────────
+
+.entrega-grid {
+    display: grid;
+    grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+    gap: 1.5rem;
+    align-items: start;
+}
+
+@media (max-width: 900px) {
+    .entrega-grid {
+        grid-template-columns: minmax(0, 1fr);
+    }
+}
+
+.entrega-panel {
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: var(--bs-border-radius);
+    padding: 1.25rem;
+}
+
+.entrega-panel + .entrega-panel {
+    margin-top: 1.5rem;
+}
+
+.entrega-panel__title {
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: var(--text-primary);
+    margin: 0 0 1rem;
+}
+
+.entrega-meta {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    gap: 0.5rem 1rem;
+    font-size: 0.85rem;
+}
+
+.entrega-meta dt {
+    color: var(--text-secondary);
+    font-weight: 500;
+}
+
+.entrega-meta dd {
+    margin: 0;
+    color: var(--text-primary);
+    overflow-wrap: anywhere;
+}
+
+// Lista de vínculos: cada item é removível, que é o ponto do épico —
+// antes era uma string única que ninguém conseguia editar item a item.
+.link-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.link-item {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 0.65rem;
+    border: 1px solid var(--border-color);
+    border-radius: var(--bs-border-radius-sm);
+    background: var(--bg-color);
+}
+
+.link-item__kind {
+    font-size: 0.68rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--text-secondary);
+    font-weight: 600;
+    flex-shrink: 0;
+}
+
+.link-item__url {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: var(--accent-color);
+}
+
+// ── Configuração da esteira ─────────────────────────────────────────────────
+
+.pipeline-editor {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.pipeline-row {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr) auto;
+    gap: 0.75rem;
+    align-items: center;
+    padding: 0.75rem;
+    border: 1px solid var(--border-color);
+    border-radius: var(--bs-border-radius-sm);
+    background: var(--card-bg);
+}
+
+@media (max-width: 768px) {
+    .pipeline-row {
+        grid-template-columns: minmax(0, 1fr);
+    }
+}
+
+.pipeline-row__order {
+    font-variant-numeric: tabular-nums;
+    color: var(--text-secondary);
+    font-weight: 600;
+    font-size: 0.8rem;
+}

--- a/src/styles/_esteira.scss
+++ b/src/styles/_esteira.scss
@@ -6,6 +6,118 @@
 // do Bootstrap 5.3.8, que é a escala oficial do projeto enquanto não houver tokens
 // próprios de espaçamento e raio.
 
+// Barra de filtros da lista principal. Quebra em coluna no mobile em vez de espremer
+// quatro selects lado a lado.
+.esteira-filters {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-end;
+    gap: 0.75rem;
+    margin-bottom: 1rem;
+}
+
+.filter-panel > summary {
+    display: none;
+}
+
+.filter-panel:not([open]) > .esteira-filters {
+    display: flex;
+}
+
+.esteira-filters__field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    min-width: 9rem;
+    flex: 1 1 9rem;
+}
+
+.esteira-filters__field label {
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--text-secondary);
+    font-weight: 600;
+}
+
+@media (max-width: 640px) {
+    .filter-panel {
+        margin-bottom: 1rem;
+        border: 1px solid var(--border-color);
+        border-radius: var(--bs-border-radius);
+        background: var(--card-bg);
+    }
+
+    .filter-panel > summary {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 0.65rem 0.75rem;
+        color: var(--text-primary);
+        font-weight: 600;
+        cursor: pointer;
+    }
+
+    .filter-panel:not([open]) > .esteira-filters {
+        display: none;
+    }
+
+    .filter-panel .esteira-filters {
+        padding: 0 0.75rem 0.75rem;
+        margin-bottom: 0;
+    }
+
+    .esteira-filters__field {
+        flex-basis: 100%;
+    }
+}
+
+@media (max-width: 860px) {
+    .dashboard-header {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 1rem;
+    }
+
+    .dashboard-header .actions {
+        flex-wrap: wrap;
+        width: 100%;
+    }
+}
+
+@media (max-width: 420px) {
+    .container {
+        padding: 1rem;
+    }
+
+    .dashboard-section-head {
+        flex-wrap: wrap;
+        gap: 0.75rem;
+    }
+
+    .dashboard-header .current-user-avatar {
+        width: 64px;
+        height: 64px;
+    }
+
+    #prModal .modal-content {
+        width: calc(100% - 1.5rem);
+        padding: 1rem;
+    }
+
+    #prModal .form-grid {
+        grid-template-columns: minmax(0, 1fr);
+    }
+
+    #prModal .form-group.full-width {
+        grid-column: auto;
+    }
+
+    #prForm {
+        padding-right: 0.25rem;
+    }
+}
+
 .pipeline-matrix {
     display: flex;
     align-items: center;
@@ -158,6 +270,56 @@
     color: var(--accent-color);
 }
 
+// Formulário de novo vínculo dentro do modal de PR.
+.pr-link-form {
+    display: grid;
+    grid-template-columns: minmax(8rem, 0.8fr) minmax(12rem, 2fr) minmax(8rem, 1fr) auto;
+    gap: 0.5rem;
+    align-items: end;
+    margin-top: 0.5rem;
+}
+
+.pr-links-title {
+    display: block;
+    color: var(--text-primary);
+    font-weight: 600;
+}
+
+.pr-link-form__field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    min-width: 0;
+}
+
+.pr-link-form__field label {
+    color: var(--text-secondary);
+    font-size: 0.75rem;
+    font-weight: 600;
+}
+
+@media (max-width: 768px) {
+    .pr-link-form {
+        grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+    }
+
+    .pr-link-form__field--url {
+        grid-column: 1 / -1;
+        grid-row: 1;
+    }
+}
+
+@media (max-width: 420px) {
+    .pr-link-form {
+        grid-template-columns: minmax(0, 1fr);
+    }
+
+    .pr-link-form__field--url {
+        grid-column: auto;
+        grid-row: auto;
+    }
+}
+
 // ── Configuração da esteira ─────────────────────────────────────────────────
 
 .pipeline-editor {
@@ -166,9 +328,43 @@
     gap: 0.75rem;
 }
 
+.env-history__status {
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+    margin-bottom: 0.5rem;
+}
+
+.env-history__status--error {
+    color: var(--module-status-error-color);
+}
+
+.module-empty-state--compact {
+    padding: 0.75rem;
+}
+
+.module-empty-state--compact h4 {
+    margin-bottom: 0.25rem;
+}
+
+.module-empty-state--compact p {
+    margin: 0;
+}
+
+.pipeline-editor__header {
+    display: grid;
+    grid-template-columns: 7rem minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr) auto;
+    gap: 0.75rem;
+    padding: 0 0.75rem 0.5rem;
+    color: var(--text-secondary);
+    font-size: 0.72rem;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
+
 .pipeline-row {
     display: grid;
-    grid-template-columns: auto minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr) auto;
+    grid-template-columns: 7rem minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr) auto;
     gap: 0.75rem;
     align-items: center;
     padding: 0.75rem;
@@ -178,14 +374,104 @@
 }
 
 @media (max-width: 768px) {
+    .pipeline-editor__header {
+        display: none;
+    }
+
     .pipeline-row {
         grid-template-columns: minmax(0, 1fr);
     }
 }
 
 .pipeline-row__order {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
     font-variant-numeric: tabular-nums;
     color: var(--text-secondary);
     font-weight: 600;
     font-size: 0.8rem;
+}
+
+.pipeline-move-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.25rem;
+}
+
+.pipeline-move-btn svg {
+    width: 0.9rem;
+    height: 0.9rem;
+}
+
+.batch-actions {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.page-state,
+.empty-state {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    padding: 1.5rem;
+    margin-bottom: 1rem;
+    color: var(--text-secondary);
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: var(--bs-border-radius);
+    text-align: center;
+}
+
+.page-state[hidden] {
+    display: none;
+}
+
+.page-state--error,
+.page-state--forbidden {
+    border-color: color-mix(in srgb, var(--danger-color) 35%, var(--border-color));
+}
+
+.page-state--loading svg {
+    animation: rotation 1s linear infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .page-state--loading svg {
+        animation-duration: 3s;
+    }
+}
+
+.page-state > div {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+    text-align: left;
+}
+
+#envGrid .module-card {
+    height: auto;
+    min-height: 14rem;
+}
+
+@media (max-width: 420px) {
+    .env-page-header {
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+    }
+
+    .env-page-header .actions {
+        align-self: flex-start;
+    }
+
+    #envGrid .module-card {
+        min-height: 0;
+    }
 }

--- a/src/styles/_legacy.scss
+++ b/src/styles/_legacy.scss
@@ -659,6 +659,11 @@ tr:hover {
     min-height: 46px;
 }
 
+.login-cancel {
+    width: 100%;
+    margin-top: 0.75rem;
+}
+
 .login-card .form-group input {
     width: 100%;
     min-height: 46px;
@@ -1188,6 +1193,7 @@ footer {
 
 footer p {
     display: flex;
+    flex-wrap: wrap;
     align-items: center;
     justify-content: center;
     gap: 8px;

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -7,4 +7,5 @@
 @use "bootstrap/bootstrap" as *;
 @use "core/bootstrap-theme-bridge" as *;
 @use "monitor-modal" as *;
+@use "esteira" as *;
 @use "legacy" as *;

--- a/test/authService.test.js
+++ b/test/authService.test.js
@@ -53,3 +53,15 @@ test('restoreSession solicita seleção quando o tenant salvo não pertence mais
     assert.equal(session.state, 'tenant-selection-required');
     assert.equal(LocalStorage.getItem('currentTenantId'), null);
 });
+
+test('restoreSession preserva o token quando Users/me falha temporariamente', async () => {
+    globalThis.fetch = async () => new Response('Bad Gateway', {
+        status: 502,
+        statusText: 'Bad Gateway',
+    });
+
+    const session = await AuthService.restoreSession();
+
+    assert.equal(session.state, 'unavailable');
+    assert.equal(LocalStorage.getItem('token'), 'token-de-teste');
+});


### PR DESCRIPTION
Parte de frontend do Épico 2 — esteira tradicional de entrega até Produção. O backend está em SamuelAraag/pr-manager#63 e precisa ser mesclado junto: esta entrega consome campos e endpoints novos.

Task: SamuelAraag/pr-manager#30.

## O que muda

**Lista principal ganha a coluna "Esteira".** A matriz mostra onde cada PR está em cada degrau — e as colunas saem da esteira configurada do app, não são fixas em três: um cliente pode ter dev+prod ou stg+prod.

A assimetria entre os degraus é proposital. O ambiente de integração mostra presença e desde quando, porque ali não existe versão: o código entra por merge. Os ambientes versionados mostram o número da versão. É o que diferencia "o código está mergeado" de "esta versão está implantada".

**Filtro "somente em voo", ligado por padrão.** Esconde o que já chegou ao último ambiente da esteira. Nada é apagado — desmarcar traz de volta o histórico completo. A branch de integração acumula para sempre, então sem esse filtro a coluna teria ✓ em todas as linhas depois de alguns meses e deixaria de distinguir qualquer coisa.

**Nova rota `entrega.html`.** Reúne num só lugar o que hoje está espalhado: a matriz de ambientes do PR, o ciclo, os vínculos e a timeline de eventos. Rota própria e não modal, com URL compartilhável.

**Vínculos viram itens de verdade.** A seção "Tasks Vinculadas (Max 5)" nunca entregou dado porque os vínculos eram uma string única no PR. Agora cada um é uma linha, adicionável e removível, sem limite artificial. Vínculo nunca é obrigatório — hotfix e bugfix entram sem task.

**`ambientes.html` ganha o editor da esteira.** Ordem, modo e branch de cada degrau, com remoção de ambiente não usado. É o que destrava o cliente sem staging, que antes não conseguia promover para produção de jeito nenhum.

## Estilo

Novo `src/styles/_esteira.scss`. Nenhuma cor nova: os degraus usam os tokens `--module-tag-dev/stg/prod-*` que já existiam, e o resto sai dos tokens de superfície e da escala do Bootstrap, que é a escala oficial do projeto enquanto não houver tokens próprios de espaçamento.

Presente e ausente se distinguem por preenchimento, borda tracejada e opacidade — não só por cor.

## Convenções

- Validação inline (`is-invalid` + `.field-error`), revalidando no submit; toast reservado para o resultado da API.
- `textContent` e `escapeHtml` em todo dado dinâmico; nenhuma interpolação crua em `innerHTML`.
- Telas administrativas como rota, nunca como modal do index.

## Plano de teste

`npm run build:styles` e `npm test` (13 testes) passando.

Manualmente, com o backend do PR #63 no ar:

1. Abrir a lista e conferir a coluna Esteira, com os degraus na ordem configurada do app.
2. Desmarcar "somente em voo" e conferir que os PRs já entregues reaparecem.
3. Abrir "Ver entrega" num PR: matriz, ciclo, vínculos e histórico.
4. Adicionar e remover um vínculo; salvar sem endereço e conferir o erro inline no campo.
5. Em Ambientes, remover o staging de um app que nunca implantou nele, salvar, e promover uma versão de dev direto para produção.
6. Tentar remover um ambiente que já tem deploy e conferir a mensagem de erro.
7. Alternar tema claro/escuro nas telas novas.

Fecha a parte de frontend da task SamuelAraag/pr-manager#30.
